### PR TITLE
Added HTML attributes and date validation constriant

### DIFF
--- a/modules/localgov_forms_date/localgov_forms_date.module
+++ b/modules/localgov_forms_date/localgov_forms_date.module
@@ -1,0 +1,26 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook form alter.
+ */
+function localgov_forms_webform_element_localgov_forms_date_alter(array &$element, FormStateInterface $form_state, array $context)  {
+
+  // We want our callback to trigger
+  // on localgov_forms_date webform elements
+  // Fields to apply validation callback on.
+  $webform_key = [
+    'localgov_forms_date',
+  ];
+  //
+  if (isset($element['#webform_key'], $webform_key)) {
+    // Insert the validation at the top so this check
+    // gets done first.
+    array_unshift($element['#element_validate'], [
+      '\Drupal\localgov_forms_date\Validate\LocalgovFormsDateValidateConstraint',
+      'validate',
+    ]);
+  }
+
+}

--- a/modules/localgov_forms_date/localgov_forms_date.module
+++ b/modules/localgov_forms_date/localgov_forms_date.module
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * @file
- * LocalGov Forms Date module
+ * LocalGov Forms Date module.
  */
+
 use Drupal\Core\Form\FormStateInterface;
 
 /**

--- a/modules/localgov_forms_date/localgov_forms_date.module
+++ b/modules/localgov_forms_date/localgov_forms_date.module
@@ -1,19 +1,21 @@
 <?php
-
+/**
+ * @file
+ * LocalGov Forms Date module
+ */
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Implements hook form alter.
+ * Implements hook_web_element_alter().
  */
-function localgov_forms_webform_element_localgov_forms_date_alter(array &$element, FormStateInterface $form_state, array $context)  {
+function localgov_forms_webform_element_localgov_forms_date_alter(array &$element, FormStateInterface $form_state, array $context) {
 
   // We want our callback to trigger
-  // on localgov_forms_date webform elements
-  // Fields to apply validation callback on.
+  // on localgov_forms_date webform elements.
   $webform_key = [
     'localgov_forms_date',
   ];
-  //
+
   if (isset($element['#webform_key'], $webform_key)) {
     // Insert the validation at the top so this check
     // gets done first.

--- a/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
+++ b/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
@@ -79,17 +79,23 @@ class LocalgovFormsDate extends DateList {
   public static function afterBuild(array $element, FormStateInterface $form_state) {
     $element = parent::afterBuild($element, $form_state);
 
-    // Set the property of the date of birth elements.
+    //Set the property of the date of birth elements
     $element['day']['#attributes']['placeholder'] = t('DD');
     $element['day']['#maxlength'] = 2;
+    $element['day']['#attributes']['inputmode'] = 'numeric';
+    $element['day']['#attributes']['pattern'] = '[0-9]*';
     $element['day']['#attributes']['class'][] = 'localgov_forms_date__day';
 
     $element['month']['#attributes']['placeholder'] = t('MM');
     $element['month']['#maxlength'] = 2;
+    $element['month']['#attributes']['inputmode'] = 'numeric';
+    $element['month']['#attributes']['pattern'] = '[0-9]*';
     $element['month']['#attributes']['class'][] = 'localgov_forms_date__month';
 
     $element['year']['#attributes']['placeholder'] = t('YYYY');
     $element['year']['#maxlength'] = 4;
+    $element['year']['#attributes']['inputmode'] = 'numeric';
+    $element['year']['#attributes']['pattern'] = '[0-9]*';
     $element['year']['#attributes']['class'][] = 'localgov_forms_date__year';
 
     return $element;

--- a/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
+++ b/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
@@ -79,7 +79,7 @@ class LocalgovFormsDate extends DateList {
   public static function afterBuild(array $element, FormStateInterface $form_state) {
     $element = parent::afterBuild($element, $form_state);
 
-    //Set the property of the date of birth elements
+    // Set the property of the date of birth elements.
     $element['day']['#attributes']['placeholder'] = t('DD');
     $element['day']['#maxlength'] = 2;
     $element['day']['#attributes']['inputmode'] = 'numeric';

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -6,9 +6,7 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Localgov Forms Date field validation constraint.
- *
  */
-
 class LocalgovFormsDateValidateConstraint {
 
   /**
@@ -20,6 +18,7 @@ class LocalgovFormsDateValidateConstraint {
    *   The form state.
    * @param array $form
    *   The complete form structure.
+   *
    */
   public static function validate(array &$element, FormStateInterface $form_state, array &$form) {
 

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -18,7 +18,6 @@ class LocalgovFormsDateValidateConstraint {
    *   The form state.
    * @param array $form
    *   The complete form structure.
-   *
    */
   public static function validate(array &$element, FormStateInterface $form_state, array &$form) {
 

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\localgov_forms_date\Validate;
+
+use Drupal\Core\Field\FieldException;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Localgov Forms Date field validation
+ * Form API callback. Validate element value.
+ */
+class LocalgovFormsDateValidateConstraint {
+  /**
+   * Validates given element.
+   *
+   * @param array              $element      The form element to process.
+   * @param FormStateInterface $form_state    The form state.
+   * @param array              $form The complete form structure.
+   */
+  public static function validate(array &$element, FormStateInterface $form_state, array &$form) {
+
+    $webformKey = $element['#webform_key'];
+    $date_parts = $form_state->getValue($webformKey);
+
+    // Check if the day field contains non numeric charcaters.
+    if (!empty($date_parts['day']) && !is_numeric($date_parts['day'])) {
+      $form_state->setError($element, t('The %field field must be a number.', ['%field' => t("day")]));
+    }
+
+    // Check if the month field contains non numeric charcaters.
+    if (!empty($date_parts['month']) && !is_numeric($date_parts['month'])) {
+      $form_state->setError($element, t('The %field field must be a number.', ['%field' => t("month")]));
+    }
+
+    // Check if the year field contains non numeric charcaters.
+    if (!empty($date_parts['year']) && !is_numeric($date_parts['year'])) {
+      $form_state->setError($element, t('The %field field must be a number.', ['%field' => t("year")]));
+    }
+
+  }
+
+}

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -5,15 +5,16 @@ namespace Drupal\localgov_forms_date\Validate;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Localgov Forms Date field validation
- * Form API callback. Validate element value.
+ * Localgov Forms Date field validation constraint.
  */
+
 class LocalgovFormsDateValidateConstraint {
+
   /**
    * Validates given element.
    *
    * @param array $element
-   *    The form element to process.
+   *   The form element to process.
    * @param Drupal\Core\Form\FormStateInterface $form_state
    *   The form state.
    * @param array $form

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -6,6 +6,7 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Localgov Forms Date field validation constraint.
+ *
  */
 
 class LocalgovFormsDateValidateConstraint {

--- a/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
+++ b/modules/localgov_forms_date/src/Validate/LocalgovFormsDateValidateConstraint.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_forms_date\Validate;
 
-use Drupal\Core\Field\FieldException;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -13,9 +12,12 @@ class LocalgovFormsDateValidateConstraint {
   /**
    * Validates given element.
    *
-   * @param array              $element      The form element to process.
-   * @param FormStateInterface $form_state    The form state.
-   * @param array              $form The complete form structure.
+   * @param array $element
+   *    The form element to process.
+   * @param Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param array $form
+   *   The complete form structure.
    */
   public static function validate(array &$element, FormStateInterface $form_state, array &$form) {
 


### PR DESCRIPTION
Summary of changes
---------------------
Added the HTML attribute inputmode="numeric"
Added the HTML attribute pattern="[0-9]*"  
Added a non numeric validation constraint 


Test steps
----------
Add non numeric character(s) to the day, month or year field
Click on the submit button.
A Drupal error message is displayed within the date input fieldset.


Notes
------
Why? 
This was born from a requirement that the date field alert the user to the presence of non numeric input in a date part text field input. 
The GDS Date pattern specifies date parts as text input fields which allow non numeric text input.
When a date parts fails validation an error message is displayed. 

Issue
-----
A side effect/bug exists whereby If a date parts fails validation the data inputed is changed to 0. In my opinion this is not desirable.
