### PR TITLE
Bug fix: Use renamed PHP interface and class names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
     "drupal/webform": "^6.0",
     "drupal/geocoder": "^3.20",
     "localgovdrupal/localgov_os_places_geocoder_provider": "1.x-dev"
+  },
+  "require-dev": {
+    "geocoder-php/nominatim-provider": "^5.2"
   }
 }

--- a/js/address_select.js
+++ b/js/address_select.js
@@ -158,7 +158,7 @@
       central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--postcode').val(addressSelected.postcode);
 
       // add UPRN
-      central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val(parseInt(addressSelected.uprn));
+      central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val(addressSelected.uprn);
 
       // Add any extra fields from centrahub for Twig access.
       // @See DRUP-1287.

--- a/src/AddressLookup.php
+++ b/src/AddressLookup.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\localgov_forms;
 
 use Geocoder\Location;
-use LocalgovDrupal\OsPlacesGeocoder\Model\LocationUprnInterface;
+use LocalgovDrupal\OsPlacesGeocoder\Model\AddressUprnInterface;
 
 /**
  * Address lookup service.
@@ -80,8 +80,8 @@ class AddressLookup {
       $longitude = $coordinate->getLongitude();
     }
 
-    $is_lgd_address = $addr instanceof LocationUprnInterface;
-    if ($is_lgd_address) {
+    $has_uprn = $addr instanceof AddressUprnInterface;
+    if ($has_uprn) {
       $uprn         = $addr->getUprn();
       $unique_id    = $uprn;
       $display_name = $addr->getDisplayName();

--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -153,7 +153,7 @@ class AddressLookupElement extends FormElement {
       '#attributes' => [
         'class' => ['js-address-select'],
       ],
-      '#address_type' => isset($element['#address_type']) ? $element['#address_type'] : 'residential',
+      '#address_type' => $element['#address_type'] ?? 'residential',
     ];
 
     if ($form_state->isProcessingInput()) {

--- a/tests/modules/localgov_forms_test/src/Geocoder/Provider/LocalgovMockGeocoder.php
+++ b/tests/modules/localgov_forms_test/src/Geocoder/Provider/LocalgovMockGeocoder.php
@@ -10,7 +10,7 @@ use Geocoder\Model\AddressCollection;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 use Geocoder\Provider\Provider as ProviderInterface;
-use LocalgovDrupal\OsPlacesGeocoder\Model\UprnAddress;
+use LocalgovDrupal\OsPlacesGeocoder\Model\OsPlacesAddress;
 
 /**
  * A Mock PHP Geocoder provider.
@@ -40,7 +40,7 @@ class LocalgovMockGeocoder implements ProviderInterface {
     $is_bhcc_hq    = !strcasecmp($search_string, 'BN1 1JE');
 
     if ($is_bhcc_hq) {
-      $results[] = UprnAddress::createFromArray([
+      $results[] = OsPlacesAddress::createFromArray([
         'providedBy'       => $this->getName(),
         'org'              => 'Brighton & Hove City Council',
         'houseName'        => 'Bartholomew House',

--- a/tests/src/FunctionalJavascript/GeocoderAddressLookup.php
+++ b/tests/src/FunctionalJavascript/GeocoderAddressLookup.php
@@ -65,11 +65,17 @@ class GeocoderAddressLookup extends WebDriverTestBase {
     $this->assertNotEmpty($town_textfield);
     $postcode_textfield = $page->find('css', '#edit-address-postcode');
     $this->assertNotEmpty($postcode_textfield);
+    $uprn_hidden_field = $page->find('css', '[data-drupal-selector="edit-address-uprn"]');
+    $this->assertNotEmpty($uprn_hidden_field);
+    $latitude_hidden_field = $page->find('css', '[data-drupal-selector="edit-address-lat"]');
+    $this->assertNotEmpty($latitude_hidden_field);
 
     $this->assertEquals('Brighton & Hove City Council, Bartholomew House', $address1_textfield->getValue());
     $this->assertEquals('Bartholomew Square', $address2_textfield->getValue());
     $this->assertEquals('Brighton', $town_textfield->getValue());
     $this->assertEquals('BN1 1JE', $postcode_textfield->getValue());
+    $this->assertEquals('000022062038', $uprn_hidden_field->getValue());
+    $this->assertEquals('-0.140979', $latitude_hidden_field->getValue());
   }
 
 }

--- a/tests/src/FunctionalJavascript/GeocoderAddressLookupTest.php
+++ b/tests/src/FunctionalJavascript/GeocoderAddressLookupTest.php
@@ -9,7 +9,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 /**
  * Sets up and tests a Geocoder-based address lookup plugin.
  */
-class GeocoderAddressLookup extends WebDriverTestBase {
+class GeocoderAddressLookupTest extends WebDriverTestBase {
 
   /**
    * Modules to enable.


### PR DESCRIPTION
The LocalgovDrupal\OsPlacesGeocoder\Model\LocationUprnInterface interface has been renamed to LocalgovDrupal\OsPlacesGeocoder\Model\AddressUprnInterface during recent refactoring.  But the AddressLookup service here was still using the old interface name.

Similarly, the LocalgovDrupal\OsPlacesGeocoder\Model\UprnAddress class has been renamed to LocalgovDrupal\OsPlacesGeocoder\Model\OsPlacesAddress.  The mock Geocoder used for testing was using the old class.

These were not picked up by the test earlier because I missed the "Test" suffix from the test classname and as a result the test wasn't running at all!  All fixed now :)

Also some coding standards fixes.