### PR TITLE
Fix(test run): Adding missing test dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,8 @@ jobs:
           composer --working-dir=html config repositories.1 vcs git@github.com:${LOCALGOV_DRUPAL_PROJECT}.git
           composer global config github-oauth.github.com ${{ github.token }}
           composer --working-dir=./html require --with-all-dependencies ${LOCALGOV_DRUPAL_PROJECT}:"${COMPOSER_REF} as ${LATEST_RELEASE}"
+          # Obtain test dependency.
+          composer --working-dir=./html require --dev --with-all-dependencies geocoder-php/nominatim-provider
 
       - name: Obtain the test target using Git
         if: env.HEAD_USER != 'localgovdrupal'


### PR DESCRIPTION
As mentioned in the [README](https://github.com/localgovdrupal/localgov_forms/blob/1.x/README.md#dependencies), the geocoder-php/nominatim-provider package is needed for test runs.