### PR TITLE
Fix: Date element in multistep form.

### DIFF
--- a/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
+++ b/modules/localgov_forms_date/src/Plugin/WebformElement/LocalgovFormsDate.php
@@ -101,4 +101,22 @@ class LocalgovFormsDate extends DateList {
     return $element;
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * DateBase::setDefaultValue() can only process datelist and datetime
+   * elements.  So here we pretend that we are a datelist element.  This is
+   * particularly important when this element is used as part of a composite
+   * element such as a multipage form.
+   *
+   * @see Drupal\Webform\Plugin\WebformElement\DateBase::setDefaultValue()
+   */
+  public function setDefaultValue(array &$element) {
+
+    $orig_type = $element['#type'];
+    $element['#type'] = 'datelist';
+    parent::setDefaultValue($element);
+    $element['#type'] = $orig_type;
+  }
+
 }

--- a/modules/localgov_forms_date/tests/modules/localgov_forms_date_test/config/install/webform.webform.localgov_date_test_form.yml
+++ b/modules/localgov_forms_date/tests/modules/localgov_forms_date_test/config/install/webform.webform.localgov_date_test_form.yml
@@ -1,0 +1,209 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: localgov_date_test_form
+title: 'LocalGov Date test form'
+description: ''
+category: ''
+elements: |-
+  first_page:
+    '#type': webform_wizard_page
+    '#title': 'First page'
+    first_date:
+      '#type': localgov_forms_date
+      '#title': 'First date'
+  last_page:
+    '#type': webform_wizard_page
+    '#title': 'Last page'
+    last_date:
+      '#type': localgov_forms_date
+      '#title': 'Last date'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/modules/localgov_forms_date/tests/src/Functional/MultipageTest.php
+++ b/modules/localgov_forms_date/tests/src/Functional/MultipageTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\localgov_forms_date;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests localgov_forms_date.
+ *
+ * Tests the LocalGov Forms Date Webform element in the context of a Multipage
+ * Webform.
+ */
+class MultipageTest extends BrowserTestBase {
+
+  /**
+   * Loading a filled in localgov date elememt should not cause PHP exception.
+   *
+   * Testing the fix for this PHP exception:
+   * "Exception: Error: Call to a member function format() on string"
+   *
+   * Test steps:
+   * - Uses a two page Webform.  Both pages have a LocalGov Forms Date Webform
+   *   element.
+   * - Fills in the date field on the first page and proceeds to the next page.
+   * - Clicks the "Previous" button to return to the first page.
+   */
+  public function testReturnToPreviousPage() :void {
+
+    // Load the first page of the form.
+    $this->drupalGet('/webform/localgov_date_test_form');
+
+    // Fill in the date element and then proceed to the next page.
+    $form_values = [
+      'first_date[day]'   => 1,
+      'first_date[month]' => 2,
+      'first_date[year]'  => 2003,
+    ];
+    $this->submitForm($form_values, 'Next');
+
+    // Try to return to the previous page.  This should not generate any error.
+    $this->submitForm([], 'Previous');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_forms_date',
+    'localgov_forms_date_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+}


### PR DESCRIPTION
Multiple *LocalGov Forms Date* Webform elements in multistep Webforms is causing WSOD (White screen of death).  This is because the parent class of the *LocalGov Form Date* element has the `datelist` element name hardcoded into it. So it fails for localgov_forms_date.  As a work-around, we override the relevant parent method.