### PR TITLE
Feature: Token support for UPRN from address lookup

### DIFF
--- a/js/address_select.js
+++ b/js/address_select.js
@@ -165,12 +165,9 @@
       central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--town-city').val(addressSelected.town);
       central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--postcode').val(addressSelected.postcode);
 
-      // add UPRN
-      central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val(addressSelected.uprn);
-
       // Add any extra fields from centrahub for Twig access.
       // @See DRUP-1287.
-      var extra_elements = ['lat', 'lng', 'ward'];
+      var extra_elements = ['lat', 'lng', 'uprn', 'ward'];
       $.each(extra_elements, function (index, value) {
         central_hub_webform_address_container.find('input.js-localgov-forms-webform-uk-address--' + value).val(addressSelected[value]);
       });
@@ -191,14 +188,10 @@
    */
   var localgov_forms_webform_manual_address_change_handler = function () {
     var central_hub_webform_address_container = $(this).closest('.js-webform-type-localgov-webform-uk-address');
-    var central_hub_webfrom_address_entry = $(this).closest('.js-address-entry-container');
-
-    // Clear UPRN.
-    central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val('');
 
     // Clear any extra fields from centrahub for Twig access.
     // @See DRUP-1287.
-    var extra_elements = ['lat', 'lng', 'ward'];
+    var extra_elements = ['lat', 'lng', 'uprn', 'ward'];
     $.each(extra_elements, function (index, value) {
       central_hub_webform_address_container.find('input.js-localgov-forms-webform-uk-address--' + value).val('');
     });

--- a/src/Element/LocalgovWebformUKAddress.php
+++ b/src/Element/LocalgovWebformUKAddress.php
@@ -17,6 +17,12 @@ use Drupal\webform\Utility\WebformElementHelper;
  * Webform composite can not contain multiple value elements (i.e. checkboxes)
  * or composites (i.e. webform_address)
  *
+ * Tokens for sub-elements of composite webform elements are available
+ * from webform submissions.  For this element, available sub-elements include:
+ * lat, lng, uprn, and ward.  The address_lookup and address_entry
+ * sub-elements always return empty token values.  Example token:
+ * [webform_submission:values:WEBFORM-ELEMENT-ID-GOES-HERE:uprn]
+ *
  * @FormElement("localgov_webform_uk_address")
  *
  * @see \Drupal\webform\Element\WebformCompositeBase
@@ -54,18 +60,6 @@ class LocalgovWebformUKAddress extends WebformUKAddress {
       '#tree' => TRUE,
     ] + parent::getCompositeElements($element);
 
-    // Add UPRN element.
-    // Seperate element as the select box is dynamic and can get erased.
-    // This should also allow the default support in case management handler.
-    $elements['address_entry']['uprn'] = [
-      '#type' => 'hidden',
-      '#title' => 'UPRN',
-      '#default_value' => '',
-      '#attributes' => [
-        'class' => ['js-localgov-forms-webform-uk-address--uprn'],
-      ],
-    ];
-
     if (!empty($element['#webform_composite_elements']['address_entry']['#required'])) {
       $elements['address_entry']['address_1']['#required'] = TRUE;
       $elements['address_entry']['town_city']['#required'] = TRUE;
@@ -75,7 +69,7 @@ class LocalgovWebformUKAddress extends WebformUKAddress {
     // Extras to store information for webform builders to access in
     // computed twig.
     // @See DRUP-1287.
-    $extra_elements = ['lat', 'lng', 'ward'];
+    $extra_elements = ['lat', 'lng', 'uprn', 'ward'];
     foreach ($extra_elements as $extra_element) {
       $elements[$extra_element] = [
         '#type' => 'hidden',


### PR DESCRIPTION
The [UPRN](https://en.wikipedia.org/wiki/Unique_Property_Reference_Number) portion of addresses selected through the [address lookup element](https://github.com/localgovdrupal/localgov_forms/blob/1.x/src/Plugin/WebformElement/LocalgovWebformUKAddress.php) can now be used in webform submission tokens.  Example token: `[webform_submission:values:WEBFORM-ELEMENT-ID:uprn]`.  This token is particularly useful during external system integration such as a CRM.  This is because UPRNs are often used to reference addresses.

Additionally, UPRNs can now be included in form submission results *tables*.

### Test steps
- Create a webform with a "LocalGov address lookup" element.
- Add an email handler.   Assuming the above address lookup element's machine id is "foo", add this token in the email body: `[webform_submission:values:foo:uprn]`
- Open the webform, do an address lookup, then submit the form.
- The resultant email should include the UPRN of the selected address.
- The `foo:uprn` item should also be available for inclusion in the Webform submissions table displayed in the "Results" tab of all webforms.