### PR TITLE
Feature: Token support

### DIFF
--- a/js/address_select.js
+++ b/js/address_select.js
@@ -32,9 +32,9 @@
   /**
    * Hide manual address form.
    *
-   * @param  {jQuery} centralHubElement
+   * @param {jQuery} centralHubElement
    *   Central hub address lookup element.
-   * @param  {String} type
+   * @param {String} type
    *   'soft' = Do not clear the address values.
    *            (used when an address is selected)
    *   'hard' = Clear the address values.
@@ -87,7 +87,8 @@
 
   /**
    * Check if a manual address has been entered.
-   * @param  {jQuery}  centralHubElement
+   *
+   * @param {jQuery} centralHubElement
    *   Centralhub address element.
    * @return {Boolean}
    *   True if the a manual address is present and the search box is empty.
@@ -110,7 +111,8 @@
 
   /**
    * Hide errors on an element
-   * @param  {jQuery} indvElement
+   *
+   * @param {jQuery} indvElement
    *   The individual form input element to hide errors.
    */
   function hideErrorsOnElement(indvElement) {

--- a/js/address_select.js
+++ b/js/address_select.js
@@ -165,12 +165,9 @@
       central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--town-city').val(addressSelected.town);
       central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--postcode').val(addressSelected.postcode);
 
-      // add UPRN
-      central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val(addressSelected.uprn);
-
       // Add any extra fields from centrahub for Twig access.
       // @See DRUP-1287.
-      var extra_elements = ['lat', 'lng', 'ward'];
+      var extra_elements = ['lat', 'lng', 'uprn', 'ward'];
       $.each(extra_elements, function (index, value) {
         central_hub_webform_address_container.find('input.js-localgov-forms-webform-uk-address--' + value).val(addressSelected[value]);
       });
@@ -191,14 +188,10 @@
    */
   var localgov_forms_webform_manual_address_change_handler = function () {
     var central_hub_webform_address_container = $(this).closest('.js-webform-type-localgov-webform-uk-address');
-    var central_hub_webfrom_address_entry = $(this).closest('.js-address-entry-container');
-
-    // Clear UPRN.
-    central_hub_webfrom_address_entry.find('input.js-localgov-forms-webform-uk-address--uprn').val('');
 
     // Clear any extra fields from centrahub for Twig access.
     // @See DRUP-1287.
-    var extra_elements = ['lat', 'lng', 'ward'];
+    var extra_elements = ['lat', 'lng', 'uprn', 'ward'];
     $.each(extra_elements, function (index, value) {
       central_hub_webform_address_container.find('input.js-localgov-forms-webform-uk-address--' + value).val('');
     });

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -5,11 +5,18 @@
  * Hook implementations.
  */
 
+use Drupal\Core\Render\Element;
+
 /**
  * Implements hook_theme().
  */
 function localgov_forms_theme() {
   return [
+    // Form element: localgov_webform_uk_address.
+    'localgov_forms_uk_address_lookup' => [
+      'render element' => 'element',
+    ],
+    // Form element: webform_uk_address.
     'localgov_forms_uk_address' => [
       'render element' => 'element',
     ],
@@ -17,19 +24,33 @@ function localgov_forms_theme() {
 }
 
 /**
- * Prepares variables for BHCC Webform templates.
+ * Implements hook_preprocess_localgov_forms_uk_address_lookup().
  *
- * Default template: localgov-forms-uk-address.html.twig.
+ * Prepares variables for the Address lookup element template.
  *
- * @param array $variables
- *   An associative array containing:
- *   - element: An associative array containing the properties of the element.
+ * Makes sub-elements available within the `content` variable.  Mostly lifted
+ * from _template_preprocess_webform_composite().
  */
-function template_preprocess_localgov_forms_uk_address(array &$variables) {
-  // Here you can get the composite element and alter it.
-  Drupal::moduleHandler()->loadInclude('webform', 'inc', 'includes/webform.theme.template');
+function localgov_forms_preprocess_localgov_forms_uk_address_lookup(array &$variables) {
 
-  _template_preprocess_webform_composite($variables);
+  $element = $variables['element'];
+  foreach (Element::children($element) as $key) {
+    if (!isset($element[$key]['#access']) || $element[$key]['#access']) {
+      $variables['content'][$key] = $element[$key];
+    }
+  }
+
+  $variables['flexbox'] = $element['#flexbox'] ?? FALSE;
+}
+
+/**
+ * Implements hook_preprocess_localgov_forms_uk_address().
+ *
+ * Prepares variables for the UK address element template.
+ */
+function localgov_forms_preprocess_localgov_forms_uk_address(array &$variables) {
+
+  localgov_forms_preprocess_localgov_webform_uk_address($variables);
 }
 
 /**

--- a/src/Element/LocalgovWebformUKAddress.php
+++ b/src/Element/LocalgovWebformUKAddress.php
@@ -17,6 +17,12 @@ use Drupal\webform\Utility\WebformElementHelper;
  * Webform composite can not contain multiple value elements (i.e. checkboxes)
  * or composites (i.e. webform_address)
  *
+ * Tokens for sub-elements of composite webform elements are available
+ * from webform submissions.  For this element, available sub-elements include:
+ * lat, lng, uprn, and ward.  The address_lookup and address_entry
+ * sub-elements always return empty token values.  Example token:
+ * [webform_submission:values:WEBFORM-ELEMENT-ID-GOES-HERE:uprn]
+ *
  * @FormElement("localgov_webform_uk_address")
  *
  * @see \Drupal\webform\Element\WebformCompositeBase
@@ -54,18 +60,6 @@ class LocalgovWebformUKAddress extends WebformUKAddress {
       '#tree' => TRUE,
     ] + parent::getCompositeElements($element);
 
-    // Add UPRN element.
-    // Seperate element as the select box is dynamic and can get erased.
-    // This should also allow the default support in case management handler.
-    $elements['address_entry']['uprn'] = [
-      '#type' => 'hidden',
-      '#title' => 'UPRN',
-      '#default_value' => '',
-      '#attributes' => [
-        'class' => ['js-localgov-forms-webform-uk-address--uprn'],
-      ],
-    ];
-
     if (!empty($element['#webform_composite_elements']['address_entry']['#required'])) {
       $elements['address_entry']['address_1']['#required'] = TRUE;
       $elements['address_entry']['town_city']['#required'] = TRUE;
@@ -75,7 +69,7 @@ class LocalgovWebformUKAddress extends WebformUKAddress {
     // Extras to store information for webform builders to access in
     // computed twig.
     // @See DRUP-1287.
-    $extra_elements = ['lat', 'lng', 'ward'];
+    $extra_elements = ['lat', 'lng', 'uprn', 'ward'];
     foreach ($extra_elements as $extra_element) {
       $elements[$extra_element] = [
         '#type' => 'hidden',

--- a/src/Plugin/WebformElement/AddressLookupElement.php
+++ b/src/Plugin/WebformElement/AddressLookupElement.php
@@ -13,7 +13,7 @@ use Drupal\webform\Plugin\WebformElementBase;
  *
  * @WebformElement(
  *   id = "localgov_forms_address_lookup",
- *   label = @Translation("LocalGov Address lookup"),
+ *   label = @Translation("LocalGov Address select"),
  *   description = @Translation("Address lookup element."),
  *   category = @Translation("LocalGov Forms"),
  *   hidden = TRUE,

--- a/src/Plugin/WebformElement/UKAddressLookup.php
+++ b/src/Plugin/WebformElement/UKAddressLookup.php
@@ -115,7 +115,7 @@ class UKAddressLookup extends WebformCompositeBase {
       ($value['address_2'] ? ' ' . $value['address_2'] : '') .
       ($value['town_city'] ? ' ' . $value['town_city'] : '') .
       ($value['postcode'] ? ' ' . $value['postcode'] : '');
-    $lines = $full_address_line ? [$full_address_line]: [];
+    $lines = $full_address_line ? [$full_address_line] : [];
     return $lines;
   }
 

--- a/src/Plugin/WebformElement/UKAddressLookup.php
+++ b/src/Plugin/WebformElement/UKAddressLookup.php
@@ -3,6 +3,7 @@
 namespace Drupal\localgov_forms\Plugin\WebformElement;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
@@ -10,7 +11,7 @@ use Drupal\webform\WebformSubmissionInterface;
  *
  * @WebformElement(
  *   id = "localgov_webform_uk_address",
- *   label = @Translation("Localgov address lookup"),
+ *   label = @Translation("LocalGov address lookup"),
  *   description = @Translation("Provides a UK address lookup element."),
  *   category = @Translation("Composite elements"),
  *   multiline = TRUE,
@@ -24,7 +25,7 @@ use Drupal\webform\WebformSubmissionInterface;
  * @see \Drupal\webform\Plugin\WebformElementInterface
  * @see \Drupal\webform\Annotation\WebformElement
  */
-class LocalgovWebformUKAddress extends WebformUKAddress {
+class UKAddressLookup extends WebformCompositeBase {
 
   /**
    * Declares our properties.

--- a/src/Plugin/WebformElement/UKAddressLookup.php
+++ b/src/Plugin/WebformElement/UKAddressLookup.php
@@ -111,12 +111,11 @@ class UKAddressLookup extends WebformCompositeBase {
   protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
     $value = $this->getValue($element, $webform_submission, $options);
 
-    $lines = [];
-    $lines[] =
-      ($value['address_1'] ? $value['address_1'] : '') .
+    $full_address_line = ($value['address_1'] ? $value['address_1'] : '') .
       ($value['address_2'] ? ' ' . $value['address_2'] : '') .
       ($value['town_city'] ? ' ' . $value['town_city'] : '') .
       ($value['postcode'] ? ' ' . $value['postcode'] : '');
+    $lines = $full_address_line ? [$full_address_line]: [];
     return $lines;
   }
 

--- a/src/Plugin/WebformElement/WebformUKAddress.php
+++ b/src/Plugin/WebformElement/WebformUKAddress.php
@@ -11,7 +11,7 @@ use Drupal\webform\WebformSubmissionInterface;
  * @WebformElement(
  *   id = "webform_uk_address",
  *   label = @Translation("UK Address"),
- *   description = @Translation("Provides a UK address lookup webform element."),
+ *   description = @Translation("Provides a UK address entry webform element."),
  *   category = @Translation("Composite elements"),
  *   multiline = TRUE,
  *   composite = TRUE,

--- a/templates/localgov-forms-uk-address-lookup.html.twig
+++ b/templates/localgov-forms-uk-address-lookup.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Default theme implementation of our Address lookup element.
+ *
+ * Available variables:
+ * - content: The webform example composite to be output.
+ *
+ * @ingroup themeable
+ */
+#}
+
+{{ attach_library('localgov_forms/localgov_forms_uk_address') }}
+
+{{ content }}


### PR DESCRIPTION
Token support for sub-elements of our Address lookup Webform composite element.   Example tokens:
- Address line 1: `[webform_submission:values:WEBFORM-ELEMENT-ID:address_1]`
- Address line 2: `[webform_submission:values:WEBFORM-ELEMENT-ID:address_2]`
- Town: `[webform_submission:values:WEBFORM-ELEMENT-ID:town_city]`
- Postcode: `[webform_submission:values:WEBFORM-ELEMENT-ID:postcode]`
- Latitude: `[webform_submission:values:WEBFORM-ELEMENT-ID:lat]`
- Longitude: `[webform_submission:values:WEBFORM-ELEMENT-ID:lng]`
- UPRN: `[webform_submission:values:WEBFORM-ELEMENT-ID:uprn]`
- Ward: `[webform_submission:values:WEBFORM-ELEMENT-ID:ward]`

This is a continuation of the work done in #47 