### PR TITLE
Fix: Template preprocess function names

### DIFF
--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -24,14 +24,12 @@ function localgov_forms_theme() {
 }
 
 /**
- * Implements hook_preprocess_localgov_forms_uk_address_lookup().
- *
  * Prepares variables for the Address lookup element template.
  *
  * Makes sub-elements available within the `content` variable.  Mostly lifted
  * from _template_preprocess_webform_composite().
  */
-function localgov_forms_preprocess_localgov_forms_uk_address_lookup(array &$variables) {
+function template_preprocess_localgov_forms_uk_address_lookup(array &$variables) {
 
   $element = $variables['element'];
   foreach (Element::children($element) as $key) {
@@ -44,13 +42,11 @@ function localgov_forms_preprocess_localgov_forms_uk_address_lookup(array &$vari
 }
 
 /**
- * Implements hook_preprocess_localgov_forms_uk_address().
- *
  * Prepares variables for the UK address element template.
  */
-function localgov_forms_preprocess_localgov_forms_uk_address(array &$variables) {
+function template_preprocess_localgov_forms_uk_address(array &$variables) {
 
-  localgov_forms_preprocess_localgov_webform_uk_address($variables);
+  template_preprocess_localgov_forms_uk_address_lookup($variables);
 }
 
 /**


### PR DESCRIPTION
The localgov_forms module registers the following themes:
- localgov_forms_uk_address_lookup
- localgov_forms_uk_address

So their preprocess functions should implement template_preprocess_HOOK() instead of MODULE_preprocess_HOOK().  Quoting [relevant documentation](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Render!theme.api.php/group/themeable/10#sec_preprocess_templates):
> template_preprocess_HOOK(&$variables): Should be implemented by the module that registers the theme hook, to set up default variables.