### PR TITLE
Feature: Display Adddress lookup element title by default

### DIFF
--- a/src/AddressLookup.php
+++ b/src/AddressLookup.php
@@ -27,7 +27,7 @@ class AddressLookup {
       return [];
     }
 
-    $formatted_addr_list = array_map('self::reformat', iterator_to_array($addr_list));
+    $formatted_addr_list = array_map([static::class, 'reformat'], iterator_to_array($addr_list));
 
     return $formatted_addr_list;
   }

--- a/src/Plugin/WebformElement/UKAddressLookup.php
+++ b/src/Plugin/WebformElement/UKAddressLookup.php
@@ -28,19 +28,32 @@ use Drupal\webform\WebformSubmissionInterface;
 class UKAddressLookup extends WebformCompositeBase {
 
   /**
-   * Declares our properties.
+   * Declares and overrides properties.
    *
-   * Configurable properties:
+   * Declares these configurable properties:
    * - geocoder_plugins
    * - always_display_manual_address_entry_btn.
+   *
+   * Overrides the `title_display` property.  By default, composite elements
+   * keep their title invisible.  We want it to be very much visible.
+   *
+   * @see Drupal\webform\Plugin\WebformElementBase::form()
    *
    * {@inheritdoc}
    */
   protected function defineDefaultProperties() {
 
     $parent_properties = parent::defineDefaultProperties();
+
     $parent_properties['geocoder_plugins'] = [];
     $parent_properties['always_display_manual_address_entry_btn'] = 'yes';
+
+    // We are trying to select the "Default" title display setting which results
+    // in a visible title.  But the "Default" option uses an empty string as its
+    // key and providing an empty key here does nothing.  As a work-around, we
+    // are using "default" which, while not among the available option keys,
+    // does the job perfectly.
+    $parent_properties['title_display'] = 'default';
 
     return $parent_properties;
   }


### PR DESCRIPTION
We want to display the title of the Address lookup element by default.  At the moment, the relevant configuration chooses "Invisible" title display by default.

Closes #64 

### Test steps
- Add an Address lookup element to a form.  Leave the "Form display > Title display" setting **untouched**.
- View the form.
- The title of the Address lookup element should appear on the form.