### PR TITLE
Revert "Replaces deprecated class from address element class"

### DIFF
--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -4,14 +4,14 @@ namespace Drupal\localgov_forms\Element;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element\FormElementBase;
+use Drupal\Core\Render\Element\FormElement;
 
 /**
  * Provides a central hub address lookup element.
  *
  * @FormElement("localgov_forms_address_lookup")
  */
-class AddressLookupElement extends FormElementBase {
+class AddressLookupElement extends FormElement {
 
   /**
    * Static search string.


### PR DESCRIPTION
Reverts localgovdrupal/localgov_forms#83

Because [10.2 is still supported until December 2024](https://www.drupal.org/about/core/policies/core-release-cycles/schedule#current). 

Alternativly we reset the commit history on 1.x and release-1.x and repoen the original PR.