### PR TITLE
 Replaces deprecated class from address element class

### DIFF
--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -4,14 +4,14 @@ namespace Drupal\localgov_forms\Element;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element\FormElement;
+use Drupal\Core\Render\Element\FormElementBase;
 
 /**
  * Provides a central hub address lookup element.
  *
  * @FormElement("localgov_forms_address_lookup")
  */
-class AddressLookupElement extends FormElement {
+class AddressLookupElement extends FormElementBase {
 
   /**
    * Static search string.


### PR DESCRIPTION
This is a revert of a revert, once 10.2 is no longer supported.
Original is #83 by @MattOz-CDS.

> Replaces deprecated class from address element so that the Static analysis checks pass
