### PR TITLE
adds feedback form

### DIFF
--- a/modules/localgov_forms_feedback_form/README.md
+++ b/modules/localgov_forms_feedback_form/README.md
@@ -1,0 +1,16 @@
+# LocalGov Forms - Feedback Form
+
+## What is it?
+This is a small module that creates a feedback for for your LocalGov Drupal website.
+
+It asks a simple question: "Was this page helpful?".
+
+If someone answers "Yes", they are asked if they'd like to share what is good about this page. If they answer "No", they have the opportunity to say how the page can be improved.
+
+## How to use it.
+- Install it like any other Drupal module from the "Extend" page.
+- Add a block of type "Webform" to your site via the `Admin > Structure > Blocks` page.
+- When the form is submitted, results will be stored in the database. They can be accessed by going to `Admin > Structure > Webforms`, clicking on the "LocalGov Forms Feedback Form", and then choosing "Results".
+
+Maintainers:
+- Mark Conroy

--- a/modules/localgov_forms_feedback_form/README.md
+++ b/modules/localgov_forms_feedback_form/README.md
@@ -12,5 +12,8 @@ If someone answers "Yes", they are asked if they'd like to share what is good ab
 - Add a block of type "Webform" to your site via the `Admin > Structure > Blocks` page.
 - When the form is submitted, results will be stored in the database. They can be accessed by going to `Admin > Structure > Webforms`, clicking on the "LocalGov Forms Feedback Form", and then choosing "Results".
 
+## Considerations
+When you enable this module, the form that is created is set to store data in your website's database. This is the default datastore for webforms. However, this may not be where your data protection officer wishes you to store webform submissions. Check with your DPO before deploying this to a live site, or else edit the form configuration to store the data somewhere else - a CRM, an offsite backup, a separate database, etc.
+
 Maintainers:
 - Mark Conroy

--- a/modules/localgov_forms_feedback_form/config/install/webform.webform.localgov_forms_feedback_form.yml
+++ b/modules/localgov_forms_feedback_form/config/install/webform.webform.localgov_forms_feedback_form.yml
@@ -1,0 +1,223 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: localgov_forms_feedback_form
+title: 'Feedback Form'
+description: 'A simple "was this page helpful" feedback form.'
+categories: {  }
+elements: |-
+  was_this_page_helpful:
+    '#type': radios
+    '#title': 'Was this page helpful?'
+    '#options':
+      'Yes': 'Yes'
+      'No': 'No'
+  response_for_yes:
+    '#type': textarea
+    '#title': 'Great. Want to tell us what you liked about it?'
+    '#states':
+      visible:
+        ':input[name="was_this_page_helpful"]':
+          value: 'Yes'
+  response_for_no:
+    '#type': textarea
+    '#title': 'Sorry to hear that. How can we improve it?'
+    '#states':
+      visible:
+        ':input[name="was_this_page_helpful"]':
+          value: 'No'
+css: localgov-forms-feedback-form
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes:
+    class:
+      - localgov-forms-feedback-form
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns:
+    - serial
+    - created
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: false
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: inline
+  confirmation_url: ''
+  confirmation_title: 'Thanks for your feedback'
+  confirmation_message: 'Thank you for that feedback, we will use it to improve our website.'
+  confirmation_attributes: {  }
+  confirmation_back: false
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/modules/localgov_forms_feedback_form/css/localgov-forms-feedback-form.css
+++ b/modules/localgov_forms_feedback_form/css/localgov-forms-feedback-form.css
@@ -1,0 +1,4 @@
+.localgov-forms-feedback-form .fieldset-wrapper > * {
+  display: flex;
+  gap: 1rem;
+}

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.info.yml
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.info.yml
@@ -1,0 +1,8 @@
+name: LocalGov Forms Feedback Form
+type: module
+description: A simple feedback form for LocalGov Drupal.
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - 'webform:webform'
+  - 'webform:webform_ui'

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.install
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for LGD Forms Feedback Form module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function localgov_forms_feedback_form_install() {
+  \Drupal::messenger()->addStatus(t('You have installed the LocalGov Forms Feedback Form. This form stores the form submissions in the database. Make sure you have checked this is okay with your data protection officer, or else change the form settings to store the data somewhere else.'));
+}

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.libraries.yml
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.libraries.yml
@@ -1,0 +1,4 @@
+localgov_forms_feedback_form:
+  css:
+    theme:
+      css/localgov-forms-feedback-form.css: {}

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
@@ -11,10 +11,3 @@
 function localgov_forms_feedback_form_form_webform_submission_localgov_forms_feedback_form_add_form_alter(&$form, $form_state, $form_id) {
   $form['#attached']['library'][] = 'localgov_forms_feedback_form/localgov_forms_feedback_form';
 }
-
-/**
- * Implements hook_form_alter().
- */
-function localgov_forms_feedback_form_form_alter(&$form, $form_state, $form_id) {
-  dump($form_id);
-}

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
@@ -1,6 +1,8 @@
 <?php
+
 /**
- * @file Module file for the Localgov Forms Feedback Form module.
+ * @file
+ * Module file for the Localgov Forms Feedback Form module.
  */
 
 /**

--- a/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
+++ b/modules/localgov_forms_feedback_form/localgov_forms_feedback_form.module
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file Module file for the Localgov Forms Feedback Form module.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function localgov_forms_feedback_form_form_webform_submission_localgov_forms_feedback_form_add_form_alter(&$form, $form_state, $form_id) {
+  $form['#attached']['library'][] = 'localgov_forms_feedback_form/localgov_forms_feedback_form';
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_forms_feedback_form_form_alter(&$form, $form_state, $form_id) {
+  dump($form_id);
+}


### PR DESCRIPTION
Closes #91 

## What does this change?

Adds a new form for a simple feedback widget.

## How to test

- Enable the `localgov_forms_feedback_form` module
- Add a block of type "Webform"
- Select the feedback form as the form you want in the block

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.