### PR TITLE
Fix: Address lookup validation

### DIFF
--- a/js/address_change.js
+++ b/js/address_change.js
@@ -58,6 +58,7 @@
    * Populate Central Hub Selected Address
    *
    * Adds the selected address to drupalSettings.centralhub.selectedAddress.
+   *
    * @param  {jQuery} selectList
    *   Address selectlist element.
    */
@@ -87,7 +88,7 @@
         var searchButton = addressLookupElement.find('.js-address-searchbutton');
         var selectListContainer = addressLookupElement.find('.js-address-select-container');
         var selectList = selectListContainer.find('.js-address-select');
-        var error = selectListContainer.find('.js-address-error');
+        var error = selectListContainer.find('.js-address-error, .error');
 
         // Change the search button to normal button.
         searchButton.attr('type', 'button');
@@ -154,7 +155,7 @@
         var searchButton = addressLookupElement.find('.js-address-searchbutton');
         var selectListContainer = addressLookupElement.find('.js-address-select-container');
         var selectList = selectListContainer.find('.js-address-select');
-        var error = selectListContainer.find('.js-address-error');
+        var error = selectListContainer.find('.js-address-error, .error');
         var resetButton = addressLookupElement.find('.js-reset-address');
         var manualButton = addressLookupElement.find('.js-manual-address');
         var manualAddressContainer = addressLookupElement.find('+ .js-address-entry-container');

--- a/js/address_select.js
+++ b/js/address_select.js
@@ -44,7 +44,6 @@
   function hideManualAddress(centralHubElement, type, settings) {
     var manualAddressContainer = centralHubElement.find('.js-address-entry-container');
     var manualButton = centralHubElement.find('.js-manual-address');
-    var addressSelectContainer = centralHubElement.find('.js-address-select-container');
     manualAddressContainer.addClass('hidden');
 
     if (type == 'hard') {
@@ -63,6 +62,7 @@
 
   /**
    * Show the manual address form elements.
+   *
    * @param  {jQuery} centralHubElement
    *   Centralhub address element.
    */
@@ -70,17 +70,10 @@
     var manualAddressContainer = centralHubElement.find('.js-address-entry-container');
     var manualButton = centralHubElement.find('.js-manual-address');
     var addressSelectContainer = centralHubElement.find('.js-address-select-container');
-    var addressSelect = addressSelectContainer.find('select');
     var searchElement = centralHubElement.find('.js-address-searchstring');
     var addressError = addressSelectContainer.find('.js-address-error');
     manualAddressContainer.removeClass('hidden');
-    // manualAddressContainer.find('input').val('');
     manualButton.hide();
-    // addressSelectContainer.addClass('hidden');
-    // addressSelect.val('0');
-    // Clear the search element when entering a manual address.
-    // This is to pass validation.
-    // searchElement.val('');
     // Remove the error element when making a manual address.
     addressError.remove();
   }
@@ -174,7 +167,6 @@
         central_hub_webform_address_container.find('input.js-localgov-forms-webform-uk-address--' + value).val(addressSelected[value]);
       });
 
-      // hideManualAddress(centralHubElement, 'soft');
       showManualAddress(centralHubElement);
     } else if ($(this).val() == 0) {
       // If choosing the empty option, clear out the address fields.
@@ -211,9 +203,6 @@
           hideManualAddress(centralHubElement, 'soft', settings);
         }
 
-        // centralHubElement.find('.js-address-searchstring').change(function() {
-        //   hideManualAddress(centralHubElement, 'hard');
-        // });
         centralHubElement.find('.js-reset-address').click(function () {
           hideManualAddress(centralHubElement, 'hard', settings);
         });

--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -189,7 +189,7 @@ class AddressLookupElement extends FormElement {
         $parent_container = $parent_container[$keyval];
       }
 
-      // Extract the parent values form container.
+      // Extract the parent values from container.
       $parent_container_values = $form_values;
       foreach ($parents as $keyval) {
         $parent_container_values = $parent_container_values[$keyval];

--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -165,6 +165,7 @@ class AddressLookupElement extends FormElement {
     $element['address_select']['address_select_list'] = [
       '#type' => 'select',
       '#title' => $element['#address_select_title'] ?? t('Select the address'),
+      '#required_error' => t('You must select an address.'),
       '#options' => [],
       '#empty_option' => '-' . t('Please choose an address') . '-',
       '#empty_value' => 0,

--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -101,6 +101,7 @@ class AddressLookupElement extends FormElement {
       '#type' => 'textfield',
       '#title' => t('Postcode or street'),
       '#description' => $element['#address_search_description'] ?? t('Enter the postcode&hellip;'),
+      '#required_error' => t('You must enter a postcode or street.'),
       '#maxlength' => 64,
       '#size' => 64,
       '#weight' => '0',

--- a/src/Element/AddressLookupElement.php
+++ b/src/Element/AddressLookupElement.php
@@ -99,7 +99,7 @@ class AddressLookupElement extends FormElement {
 
     $element['address_search']['address_searchstring'] = [
       '#type' => 'textfield',
-      '#title' => t('Postcode or Street'),
+      '#title' => t('Postcode or street'),
       '#description' => $element['#address_search_description'] ?? t('Enter the postcode&hellip;'),
       '#maxlength' => 64,
       '#size' => 64,

--- a/src/Element/UKAddressLookup.php
+++ b/src/Element/UKAddressLookup.php
@@ -161,26 +161,36 @@ class UKAddressLookup extends WebformCompositeBase {
       // Then show an error to search for a local address or select can't find
       // the address.
       if (!empty($search_string) && $element['address_lookup']['address_select']['address_select_list']['#type'] == 'markup') {
-        $form_state->setError($element, t('Search for a local address, or select "Can\'t find the address" to enter an address.'));
+        $form_state->setError($element['address_lookup']['address_search']['address_searchstring'], t('Search for a local address, or select "Can\'t find the address" to enter an address.'));
 
-        // Inline form errors don't work well for this element in this scenario.
+        // Inline form errors don't work well for this element in Ajax calls.
         // This is because the Ajax callback attached to the `Find address`
-        // button updates only part* of the address lookup element.  As a
+        // button updates only *part* of the address lookup element.  As a
         // result, any error set on any other part of the address lookup element
-        // is lost.  To avoid this, we disable inline errors here.
-        $complete_form['#disable_inline_form_errors'] = TRUE;
+        // is lost.  To avoid this, we disable inline errors here.  There is an
+        // assumption here that the `Find address` button is using Ajax.  This
+        // assumption is good enough for most cases but degrades without Ajax.
+        if ($is_address_lookup_op) {
+          $complete_form['#disable_inline_form_errors'] = TRUE;
+        }
       }
       // Else if there is a search but no address selected,
       // set the select box as required.
       elseif (!empty($search_string) && empty($selected) && !$is_address_lookup_op) {
         WebformElementHelper::setRequiredError($element['address_lookup']['address_select']['address_select_list'], $form_state);
+
+        // UI needs a hint that we are in the middle of a search.
+        $element['address_lookup']['address_search']['address_actions']['address_searchbutton']['#attributes']['class'][] = 'js-searching';
       }
       // Else mark the entire element as required.
       elseif (empty($search_string) && empty($selected)) {
         WebformElementHelper::setRequiredError($element['address_lookup']['address_search']['address_searchstring'], $form_state);
 
-        // Inline form errors don't work well in this scenario.
-        $complete_form['#disable_inline_form_errors'] = TRUE;
+        // As explained above, inline form errors don't work well for this
+        // element in Ajax calls.
+        if ($is_address_lookup_op) {
+          $complete_form['#disable_inline_form_errors'] = TRUE;
+        }
       }
 
       // Fetch errors, to allow any generated errors for the child elements
@@ -201,7 +211,7 @@ class UKAddressLookup extends WebformCompositeBase {
         unset($form_errors[$element_key . '][address_lookup][address_select][address_select_list']);
       }
 
-      // Reset form errors and reset them with the cleaned ones.
+      // Reset form errors and replace them with cleaned ones.
       $form_state->clearErrors();
       foreach ($form_errors as $error_key => $error_value) {
         $form_state->setErrorByName($error_key, $error_value);

--- a/src/Element/UKAddressLookup.php
+++ b/src/Element/UKAddressLookup.php
@@ -98,6 +98,14 @@ class UKAddressLookup extends WebformCompositeBase {
       return;
     }
 
+    // Temporarily reset the #limit_validation_errors property.  Otherwise we
+    // can't safely set and manipulate errors below.
+    //
+    // @see Drupal\Core\Form\FormState::setErrorByName()
+    // @see AddressLookupElement::processAddressLookupElement()
+    $orig_limit_validation_errors = $form_state->getLimitValidationErrors();
+    $form_state->setLimitValidationErrors(NULL);
+
     // If the element or any of its parent containers are hidden by conditions,
     // Bypass validation and clear any required element errors generated
     // for this element.
@@ -105,7 +113,7 @@ class UKAddressLookup extends WebformCompositeBase {
       $form_errors = $form_state->getErrors();
       $form_state->clearErrors();
       foreach ($form_errors as $error_key => $error_value) {
-        if (strpos($error_key, $element_key . ']') !== 0) {
+        if (strpos($error_key, $element_key . ']') === FALSE) {
           $form_state->setErrorByName($error_key, $error_value);
         }
       }
@@ -145,6 +153,8 @@ class UKAddressLookup extends WebformCompositeBase {
       !empty($element['#webform_composite_elements']['town_city']['#required']) ||
       !empty($element['#webform_composite_elements']['postcode']['#required']);
 
+    $is_address_lookup_op = $form_state->getTriggeringElement()['#name'] === $element_key . '[address_lookup][address_search][address_actions][address_searchbutton]';
+
     if ($has_access && $is_any_address_line_required) {
       // If there is an address search, but no elements to select
       // (its a markup error)
@@ -152,15 +162,25 @@ class UKAddressLookup extends WebformCompositeBase {
       // the address.
       if (!empty($search_string) && $element['address_lookup']['address_select']['address_select_list']['#type'] == 'markup') {
         $form_state->setError($element, t('Search for a local address, or select "Can\'t find the address" to enter an address.'));
+
+        // Inline form errors don't work well for this element in this scenario.
+        // This is because the Ajax callback attached to the `Find address`
+        // button updates only part* of the address lookup element.  As a
+        // result, any error set on any other part of the address lookup element
+        // is lost.  To avoid this, we disable inline errors here.
+        $complete_form['#disable_inline_form_errors'] = TRUE;
       }
       // Else if there is a search but no address selected,
       // set the select box as required.
-      elseif (!empty($search_string) && empty($selected)) {
+      elseif (!empty($search_string) && empty($selected) && !$is_address_lookup_op) {
         WebformElementHelper::setRequiredError($element['address_lookup']['address_select']['address_select_list'], $form_state);
       }
       // Else mark the entire element as required.
       elseif (empty($search_string) && empty($selected)) {
-        WebformElementHelper::setRequiredError($element, $form_state);
+        WebformElementHelper::setRequiredError($element['address_lookup']['address_search']['address_searchstring'], $form_state);
+
+        // Inline form errors don't work well in this scenario.
+        $complete_form['#disable_inline_form_errors'] = TRUE;
       }
 
       // Fetch errors, to allow any generated errors for the child elements
@@ -168,9 +188,9 @@ class UKAddressLookup extends WebformCompositeBase {
       $form_errors = $form_state->getErrors();
 
       // Loop through errors and remove child elements, except the select
-      // element.
+      // and search query elements.
       foreach ($form_errors as $error_key => $error_value) {
-        if (strpos($error_key, $element_key . ']') === 0 && $error_key != $element_key . '][address_lookup][address_select][address_select_list') {
+        if (strpos($error_key, $element_key . ']') === 0 && ($error_key !== $element_key . '][address_lookup][address_select][address_select_list' && $error_key !== $element_key . '][address_lookup][address_search][address_searchstring')) {
           unset($form_errors[$error_key]);
         }
       }
@@ -187,6 +207,10 @@ class UKAddressLookup extends WebformCompositeBase {
         $form_state->setErrorByName($error_key, $error_value);
       }
     }
+
+    // Restore original value of the `limit_validation_errors` property now that
+    // we are done with manipulating errors.
+    $form_state->setLimitValidationErrors($orig_limit_validation_errors);
 
     // Clear empty composites value.
     if (empty(array_filter($value))) {

--- a/src/Element/UKAddressLookup.php
+++ b/src/Element/UKAddressLookup.php
@@ -59,6 +59,9 @@ class UKAddressLookup extends WebformCompositeBase {
     $element_list['address_1']['#prefix'] = '<div class="js-address-entry-container">';
     $element_list['postcode']['#suffix'] = '</div>';
 
+    // Custom error message for address line 1.
+    $element_list['address_1']['#required_error'] = t('You must select an address.');
+
     // Extras to store information for webform builders to access in
     // computed twig.
     // @See DRUP-1287.
@@ -161,7 +164,7 @@ class UKAddressLookup extends WebformCompositeBase {
       // Then show an error to search for a local address or select can't find
       // the address.
       if (!empty($search_string) && $element['address_lookup']['address_select']['address_select_list']['#type'] == 'markup') {
-        $form_state->setError($element['address_lookup']['address_search']['address_searchstring'], t('Search for a local address, or select "Can\'t find the address" to enter an address.'));
+        $form_state->setError($element['address_lookup']['address_search']['address_searchstring'], t('Enter a local address, or select "Can\'t find the address".'));
 
         // Inline form errors don't work well for this element in Ajax calls.
         // This is because the Ajax callback attached to the `Find address`

--- a/src/Element/UKAddressLookup.php
+++ b/src/Element/UKAddressLookup.php
@@ -60,7 +60,7 @@ class UKAddressLookup extends WebformCompositeBase {
     $element_list['postcode']['#suffix'] = '</div>';
 
     // Custom error message for address line 1.
-    $element_list['address_1']['#required_error'] = t('You must select an address.');
+    $element_list['address_1']['#required_error'] = t('You must enter an address.');
 
     // Extras to store information for webform builders to access in
     // computed twig.
@@ -126,6 +126,7 @@ class UKAddressLookup extends WebformCompositeBase {
     // Get the search string and selected value.
     $search_string = $value['address_lookup']['address_search']['address_searchstring'];
     $selected = $value['address_lookup']['address_select']['address_select_list'] ?? [];
+    $is_address_lookup_op = $form_state->getTriggeringElement()['#name'] === $element_key . '[address_lookup][address_search][address_actions][address_searchbutton]';
 
     // Check to see if there are values in the address element form.
     $has_address_values = FALSE;
@@ -137,9 +138,8 @@ class UKAddressLookup extends WebformCompositeBase {
       }
     }
 
-    // If the select is empty, and the manual address elements are filled in,
-    // validate the parent element.
-    if (empty($selected) && $has_address_values) {
+    // If the manual address elements are filled in, validate the parent.
+    if (!$is_address_lookup_op && $has_address_values) {
       // Clear the address search string.
       // This is to avoid the select box maintaing a value
       // (it's cleared if search string is empty).
@@ -155,8 +155,6 @@ class UKAddressLookup extends WebformCompositeBase {
       !empty($element['#webform_composite_elements']['address_2']['#required']) ||
       !empty($element['#webform_composite_elements']['town_city']['#required']) ||
       !empty($element['#webform_composite_elements']['postcode']['#required']);
-
-    $is_address_lookup_op = $form_state->getTriggeringElement()['#name'] === $element_key . '[address_lookup][address_search][address_actions][address_searchbutton]';
 
     if ($has_access && $is_any_address_line_required) {
       // If there is an address search, but no elements to select

--- a/src/Element/WebformUKAddress.php
+++ b/src/Element/WebformUKAddress.php
@@ -65,6 +65,7 @@ class WebformUKAddress extends WebformCompositeBase {
     $elements['town_city'] = [
       '#type' => 'textfield',
       '#title' => t('Town/City'),
+      '#required_error' => t('You must enter the town/city.'),
       '#attributes' => [
         'data-webform-composite-id' => $html_id . '--town_city',
         // Add a namespaced class for setting the address fields
@@ -78,6 +79,7 @@ class WebformUKAddress extends WebformCompositeBase {
     $elements['postcode'] = [
       '#type' => 'textfield',
       '#title' => t('Postcode'),
+      '#required_error' => t('You must enter the postcode.'),
       '#attributes' => [
         'data-webform-composite-id' => $html_id . '--postcode',
         // Add a namespaced class for setting the address fields

--- a/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form1.yml
+++ b/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form1.yml
@@ -1,0 +1,215 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: address_error_message_test_form1
+title: 'Address error message test form 1'
+description: 'A form with no required elements.'
+categories: {  }
+elements: |-
+  does_it_have_an_address:
+    '#type': radios
+    '#title': 'Does it have an address?'
+    '#options': yes_no
+  it_s_address:
+    '#type': localgov_webform_uk_address
+    '#title': "It's address"
+    '#geocoder_plugins':
+      localgov_mock_geocoder: localgov_mock_geocoder
+      nominatim: 0
+      random: 0
+    '#title_display': ''
+    '#states':
+      visible:
+        ':input[name="does_it_have_an_address"]':
+          value: 'Yes'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form2.yml
+++ b/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form2.yml
@@ -1,0 +1,216 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: address_error_message_test_form2
+title: 'Address error message test form 2'
+description: 'A form with a required radios element.'
+categories: {  }
+elements: |-
+  does_it_have_an_address:
+    '#type': radios
+    '#title': 'Does it have an address?'
+    '#options': yes_no
+    '#required': true
+  it_s_address:
+    '#type': localgov_webform_uk_address
+    '#title': "It's address"
+    '#geocoder_plugins':
+      localgov_mock_geocoder: localgov_mock_geocoder
+      nominatim: 0
+      random: 0
+    '#title_display': ''
+    '#states':
+      visible:
+        ':input[name="does_it_have_an_address"]':
+          value: 'Yes'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form3.yml
+++ b/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form3.yml
@@ -1,0 +1,217 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: address_error_message_test_form3
+title: 'Address error message test form 3'
+description: 'A form with a required radios element.  Also has an address lookup element whose postcode subelement is required.'
+categories: {  }
+elements: |-
+  does_it_have_an_address:
+    '#type': radios
+    '#title': 'Does it have an address?'
+    '#options': yes_no
+    '#required': true
+  it_s_address:
+    '#type': localgov_webform_uk_address
+    '#title': "It's address"
+    '#geocoder_plugins':
+      localgov_mock_geocoder: localgov_mock_geocoder
+      nominatim: 0
+      random: 0
+    '#title_display': ''
+    '#states':
+      visible:
+        ':input[name="does_it_have_an_address"]':
+          value: 'Yes'
+    '#postcode__required': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form4.yml
+++ b/tests/modules/localgov_forms_test/config/install/webform.webform.address_error_message_test_form4.yml
@@ -1,0 +1,208 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: address_error_message_test_form4
+title: 'Address error message test form 4'
+description: 'A form with only an address lookup element whose postcode subelement is required.'
+categories: {  }
+elements: |-
+  address:
+    '#type': localgov_webform_uk_address
+    '#title': "It's an address"
+    '#geocoder_plugins':
+      localgov_mock_geocoder: localgov_mock_geocoder
+      nominatim: 0
+      random: 0
+    '#title_display': ''
+    '#postcode__required': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
+++ b/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
@@ -70,8 +70,8 @@ class AddressLookupErrorMsgTest extends WebDriverTestBase {
   /**
    * Address lookup element should raise error if a required subfield is empty.
    *
-   * - Submits an empty form.  Should bring up error messeges from both the
-   *   radio and address lookup elements.
+   * - Submits an empty form.  Should bring up an error messege from the radio
+   *   element.
    * - Selects a radio that does not bring up the address lookup element.  Then
    *   submits form.  Should not bring up any error messages because address
    *   lookup element is hidden.

--- a/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
+++ b/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\localgov_forms\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Tests error handling of the address lookup element.
+ *
+ * The address lookup element should only raise errors when one of its
+ * subelements are required.
+ */
+class AddressLookupErrorMsgTest extends WebDriverTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = ['localgov_forms', 'localgov_forms_test'];
+
+  /**
+   * As it says on the tin.
+   *
+   * @var array
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests address lookup element's ability to remain inactive.
+   *
+   * - Submits an empty form with no required elements.
+   */
+  public function testEmptyFormSubmission(): void {
+
+    $session_assert = $this->assertSession();
+
+    $this->drupalGet('/webform/address_error_message_test_form1');
+    $this->submitForm(edit: [], submit: 'Submit');
+    $session_assert->waitForElementVisible('css', '.webform-confirmation__message');
+
+    $session_assert->pageTextContains('Thank you, your form has been successfully submitted.');
+  }
+
+  /**
+   * Address lookup element should not tamper with errors raised by others.
+   *
+   * - Submits a form with a required radio button.  The address lookup element
+   *   should not raise any errors.
+   */
+  public function testRequiredRadio(): void {
+
+    $session_assert = $this->assertSession();
+
+    // First, try submitting an empty form.
+    $this->drupalGet('/webform/address_error_message_test_form2');
+    $this->submitForm(edit: [], submit: 'Submit');
+
+    $session_assert->statusMessageContains('Does it have an address?', type: 'error');
+
+    // Next, select the required radio and submit again.
+    $this->submitForm(edit: ['does_it_have_an_address' => 'Yes'], submit: 'Submit');
+    $session_assert->waitForElementVisible('css', '.webform-confirmation__message');
+
+    $session_assert->pageTextContains('Thank you, your form has been successfully submitted.');
+  }
+
+  /**
+   * Address lookup element should raise error if a required subfield is empty.
+   *
+   * - Submits an empty form.  Should bring up error messeges from both the
+   *   radio and address lookup elements.
+   * - Selects a radio that does not bring up the address lookup element.  Then
+   *   submits form.  Should not bring up any error messages because address
+   *   lookup element is hidden.
+   * - Selects a radio that brings up the address lookup form.  Then submits
+   *   form without selecting or entering any address.  Should result in error
+   *   messages as the postcode subelement is required but empty.
+   * - Selects radio and fills in postcode.  Form submission should succeed.
+   */
+  public function testRequiredRadioAndPostcode(): void {
+
+    $session_assert = $this->assertSession();
+
+    // Submit an empty form.
+    $this->drupalGet('/webform/address_error_message_test_form3');
+    $this->submitForm(edit: [], submit: 'Submit');
+
+    $session_assert->statusMessageContains('Does it have an address?', type: 'error');
+
+    // Submit after selecting a radio button that does not bring up the address
+    // lookup element.
+    $this->submitForm(edit: ['does_it_have_an_address' => 'No'], submit: 'Submit');
+    $session_assert->waitForElementVisible('css', '.webform-confirmation__message');
+
+    $session_assert->pageTextContains('Thank you, your form has been successfully submitted.');
+
+    // Submit after selecting a radio button that brings up the address lookup
+    // element.  But don't fill in the required postcode.
+    $this->drupalGet('/webform/address_error_message_test_form3');
+    $this->submitForm(edit: ['does_it_have_an_address' => 'Yes'], submit: 'Submit');
+    $session_assert->waitForElementVisible('css', '.messages--error');
+
+    $session_assert->statusMessageContains('Postcode or Street field is required.', type: 'error');
+    $session_assert->statusMessageContains('Postcode field is required.', type: 'error');
+
+    // Now fill in the required postcode and submit again.
+    $session_assert->buttonExists('Can\'t find the address?')->click();
+    $this->submitForm(edit: [
+      'does_it_have_an_address' => 'Yes',
+      'it_s_address[postcode]'  => 'XM4 5HQ',
+    ], submit: 'Submit');
+    $session_assert->waitForElementVisible('css', '.webform-confirmation__message');
+
+    $session_assert->pageTextContains('Thank you, your form has been successfully submitted.');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
+++ b/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
@@ -118,4 +118,47 @@ class AddressLookupErrorMsgTest extends WebDriverTestBase {
     $session_assert->pageTextContains('Thank you, your form has been successfully submitted.');
   }
 
+  /**
+   * A form with only an address element with a required postcode.
+   *
+   * Submitting the form with an empty postcode should produce error
+   * irrespective of whether the address has been selected following a lookup or
+   * manually added or altered.
+   */
+  public function testStandaloneAddress(): void {
+
+    $page           = $this->getSession()->getPage();
+    $session_assert = $this->assertSession();
+
+    $this->drupalGet('/webform/address_error_message_test_form4');
+
+    // Fill in the postcode and search for address.
+    $postcode_or_street_textfield = $page->find('css', '#edit-address-address-lookup-address-search-address-searchstring');
+    $this->assertNotEmpty($postcode_or_street_textfield);
+    $postcode_or_street_textfield->setValue('BN1 1JE');
+
+    $search_btn = $page->find('css', '#edit-address-address-lookup-address-search-address-actions-address-searchbutton');
+    $this->assertNotEmpty($search_btn);
+    $search_btn->click();
+    $session_assert->waitForElementVisible('css', '[data-drupal-selector=edit-address-address-lookup-address-select-address-select-list]');
+
+    // Select an address from the dropdown.
+    $address_dropdown = $page->find('css', '[data-drupal-selector=edit-address-address-lookup-address-select-address-select-list]');
+    $this->assertNotEmpty($address_dropdown);
+    $address_dropdown->selectOption('000022062038');
+    $session_assert->waitForElementVisible('css', '#edit-address-address-1');
+
+    // Empty postcode field.
+    $postcode_textfield = $page->find('css', '#edit-address-postcode');
+    $postcode_textfield->setValue('');
+
+    // Submitting the form with an empty postcode should produce error.
+    $submit_btn = $page->find('css', '#edit-submit');
+    $this->assertNotEmpty($submit_btn);
+    $submit_btn->click();
+    $session_assert->waitForElementVisible('css', '.messages--error');
+
+    $session_assert->statusMessageContains('Postcode', type: 'error');
+  }
+
 }

--- a/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
+++ b/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
@@ -104,7 +104,7 @@ class AddressLookupErrorMsgTest extends WebDriverTestBase {
     $session_assert->waitForElementVisible('css', '.messages--error');
 
     $session_assert->statusMessageContains('2 errors have been found:', type: 'error');
-    $session_assert->statusMessageContains('Postcode or Street', type: 'error');
+    $session_assert->statusMessageContains('Postcode or street', type: 'error');
     $session_assert->statusMessageContains('Postcode', type: 'error');
 
     // Now fill in the required postcode and submit again.

--- a/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
+++ b/tests/src/FunctionalJavascript/AddressLookupErrorMsgTest.php
@@ -103,8 +103,9 @@ class AddressLookupErrorMsgTest extends WebDriverTestBase {
     $this->submitForm(edit: ['does_it_have_an_address' => 'Yes'], submit: 'Submit');
     $session_assert->waitForElementVisible('css', '.messages--error');
 
-    $session_assert->statusMessageContains('Postcode or Street field is required.', type: 'error');
-    $session_assert->statusMessageContains('Postcode field is required.', type: 'error');
+    $session_assert->statusMessageContains('2 errors have been found:', type: 'error');
+    $session_assert->statusMessageContains('Postcode or Street', type: 'error');
+    $session_assert->statusMessageContains('Postcode', type: 'error');
 
     // Now fill in the required postcode and submit again.
     $session_assert->buttonExists('Can\'t find the address?')->click();


### PR DESCRIPTION
## What does this change?
The LocalGov address lookup element's validation process is losing existing form error messages set by other parts of a form.  Some of its own error messages are also getting lost.  This change fixes this.

I have also updated the wording for error messages shown on required fields like Address line 1 and Postcode.  Instead of saying "Postcode field is required", it now says "You must enter the postcode."  Error message wording courtesy of @DavidBAsch 

## How to test
- Create a new Webform.
- Add a set of radio buttons.  Mark it as `required`.
- Add a LocalGov address lookup element.
- Set the visibility condition of the address lookup element dependent on one of the radio buttons.
- Submit the Webform without selecting any of the radio buttons.  At the moment, form submission completes and an error message about the radio button is displayed in the **confirmation** page rather than on the form page where the form elements are.  Once this fix is applied, the form submission fails as expected.