### PR TITLE
updating address dropdown when Drupal ajax request completes

### DIFF
--- a/js/address_change.js
+++ b/js/address_change.js
@@ -209,5 +209,42 @@
       });
     }
   }
+//pop up dropdown with searched address every time a Drupal AJAX request completes
+  $(document).ajaxComplete(function () {
+    var selectElement = $('.js-address-select');
+
+    // Clear previous options
+    selectElement.empty();
+
+    // Add default option
+    var defaultOption = $('<option>', {
+      value: '0',
+      text: '-Please choose an address-'
+    });
+    selectElement.append(defaultOption);
+
+    // Check if address list exists
+    var addressList = drupalSettings.centralHub.addressList;
+
+    if (addressList && addressList.length > 0) {
+      $.each(addressList, function (index, address) {
+        var option = $('<option>', {
+          value: address.name,
+          text: address.display
+        });
+        selectElement.append(option);
+      });
+    } else {
+      var noAddressOption = $('<option>', {
+        value: '',
+        text: 'No addresses found'
+      });
+      selectElement.append(noAddressOption);
+    }
+
+    // Show the dropdown after AJAX loads addresses
+    $('.js-address-select-container').removeClass('hidden');
+  });
+
 
 })(jQuery, Drupal);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This change ensures that the address dropdown (.js-address-select) is populated immediately after the search button (.js-address-searchbutton) is clicked. Previously, the dropdown did not update in real-time, requiring additional interaction or refreshes.
**How does it solve the problem?**
Listens for AJAX completion (ajaxComplete event).
Clears and repopulates the dropdown dynamically with returned addresses.
Ensures the dropdown is displayed after the search.
## How to test

On this branch (PS_PopulateAddressInDDWithAjax)

Perform an address search.
The dropdown populates instantly with the retrieved addresses.
The reset button and manual entry options should still function as expected.
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

If AJAX fails, the dropdown might not populate, but this is handled by adding a fallback message ("No addresses found").

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)