### PR TITLE
making dropdown changes dynamic

### DIFF
--- a/js/address_change.js
+++ b/js/address_change.js
@@ -200,7 +200,7 @@
           // Set newSearch latch to false.
           drupalSettings.centralHub.newSearch = false;
 
-        // Else make sure the select box is hidden.
+          // Else make sure the select box is hidden.
         } else {
           resetButton.addClass('hidden');
           selectListContainer.addClass('hidden');
@@ -209,42 +209,62 @@
       });
     }
   }
-//pop up dropdown with searched address every time a Drupal AJAX request completes
-  $(document).ajaxComplete(function () {
-    var selectElement = $('.js-address-select');
+//below code handles the logic for Address Lookup dropdown
+  $(document).ready(function () {
+    // Store references to the clicked fieldset and dropdown
+    var clickedFieldset = null;
+    var clickedDropdown = null;
 
-    // Clear previous options
-    selectElement.empty();
+    // Log details when a fieldset is clicked
+    $('fieldset').click(function () {
+      clickedFieldset = $(this);  // Store the clicked fieldset
+     });
 
-    // Add default option
-    var defaultOption = $('<option>', {
-      value: '0',
-      text: '-Please choose an address-'
-    });
-    selectElement.append(defaultOption);
+    // Log details when the search button is clicked
+    $('.js-address-searchbutton').click(function () {
+      // Store the dropdown related to the clicked button
+      clickedDropdown = $(this).closest('fieldset').find('.js-address-select');
+     });
 
-    // Check if address list exists
-    var addressList = drupalSettings.centralHub.addressList;
+    // Handle the dropdown update after AJAX request
+    $(document).ajaxComplete(function () {
+      if (clickedDropdown) {
+        var selectElement = clickedDropdown; // Get the specific dropdown that was clicked
 
-    if (addressList && addressList.length > 0) {
-      $.each(addressList, function (index, address) {
-        var option = $('<option>', {
-          value: address.name,
-          text: address.display
+        // Clear previous options
+        selectElement.empty();
+
+        // Add default option
+        var defaultOption = $('<option>', {
+          value: '0',
+          text: '-Please choose an address-'
         });
-        selectElement.append(option);
-      });
-    } else {
-      var noAddressOption = $('<option>', {
-        value: '',
-        text: 'No addresses found'
-      });
-      selectElement.append(noAddressOption);
-    }
+        selectElement.append(defaultOption);
 
-    // Show the dropdown after AJAX loads addresses
-    $('.js-address-select-container').removeClass('hidden');
+        // Check if address list exists in drupalSettings
+        var addressList = drupalSettings.centralHub.addressList;
+
+        if (addressList && addressList.length > 0) {
+          // Add addresses to the dropdown
+          $.each(addressList, function (index, address) {
+            var option = $('<option>', {
+              value: address.name,
+              text: address.display
+            });
+            selectElement.append(option);
+          });
+        } else {
+          // If no addresses are found, show a "No addresses found" option
+          var noAddressOption = $('<option>', {
+            value: '',
+            text: 'No addresses found'
+          });
+          selectElement.append(noAddressOption);
+        }
+
+        // Show the dropdown after AJAX loads addresses
+        selectElement.closest('.js-address-select-container').removeClass('hidden');
+      }
+    });
   });
-
-
 })(jQuery, Drupal);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

with previous code , address drop down was working only for 1 dropdown in a form.
this fix will let user to add as many address field sets to add and each will have its own address dropdown populated w.r.t to address being searched

## How to test

add Two or more different Address Field sets or one can duplicate the existing one.
search the address and see the addresses being populated in the respective dropdown

## How can we measure success?

We can track how often the address dropdown is populated, especially the "No addresses found" or successful address options, and compare it to previous behavior before the fix.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)