### PR TITLE
Feature/custom webform header 3

### DIFF
--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -1,0 +1,16 @@
+.header__form_title h1 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+}
+
+.header__form_summary {
+    font-size: 1em;
+    margin-bottom: 1em;
+}
+
+.header__wizard_page_title {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 1.5em;
+}

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -4,7 +4,7 @@
     margin-bottom: 0.5em;
 }
 
-.header__form_summary p {
+.header__form_summary {
     font-size: 1.875rem !important;
     font-weight: 400 !important;
     margin-bottom: 1em;

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -1,18 +1,28 @@
 .header__form_title h1 {
-    font-size: 1.5em;
+    font-size: 1.5rem;
     font-weight: bold;
-    margin-bottom: 0.5em;
+    margin-bottom: 0.5rem;
 }
 
 .header__form_summary {
-    font-size: 1.875rem !important;
+    font-size: 1.375rem!important;
     font-weight: 400 !important;
     margin-bottom: 1em;
 }
 
 .header__wizard_page_title  {
-    font-size: 2.125em;
+    font-size: 2.125rem;
     font-weight: bold;
-    margin-bottom: 1.5em;
+    margin-bottom: 1.5rem;
 }
+
+.header__form_title_hr {
+    width: 100%;
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    border: 0;
+    border-top: 1px solid #e0e0e0;
+    border-bottom: 1px solid #e0e0e0;
+}
+.
 

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -4,15 +4,15 @@
     margin-bottom: 0.5em;
 }
 
-.header__wizard_page_title  {
-    font-size: 2.125em;
-    font-weight: bold;
-    margin-bottom: 1.5em;
-}
-
 .header__form_summary p {
     font-size: 1.875rem !important;
     font-weight: 400 !important;
     margin-bottom: 1em;
+}
+
+.header__wizard_page_title  {
+    font-size: 2.125em;
+    font-weight: bold;
+    margin-bottom: 1.5em;
 }
 

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -1,28 +1,27 @@
 .header__form_title h1 {
-    font-size: 1.5rem;
-    font-weight: bold;
-    margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
 }
 
 .header__form_summary {
-    font-size: 1.375rem!important;
-    font-weight: 400 !important;
-    margin-bottom: 1em;
+  font-size: 1.375rem!important;
+  font-weight: 400 !important;
+  margin-bottom: 1em;
 }
 
-.header__wizard_page_title  {
-    font-size: 2.125rem;
-    font-weight: bold;
-    margin-bottom: 1.5rem;
+.header__wizard_page_title {
+  font-size: 2.125rem;
+  font-weight: bold;
+  margin-bottom: 1.5rem;
 }
 
 .header__form_title_hr {
-    width: 100%;
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-    border: 0;
-    border-top: 1px solid #e0e0e0;
-    border-bottom: 1px solid #e0e0e0;
+  width: 100%;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  border: 0;
+  border-top: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
 }
 .
-

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -4,13 +4,15 @@
     margin-bottom: 0.5em;
 }
 
-.header__form_summary {
-    font-size: 1em;
-    margin-bottom: 1em;
-}
-
-.header__wizard_page_title {
-    font-size: 1.5em;
+.header__wizard_page_title  {
+    font-size: 2.125em;
     font-weight: bold;
     margin-bottom: 1.5em;
 }
+
+.header__form_summary p {
+    font-size: 1.875rem !important;
+    font-weight: 400 !important;
+    margin-bottom: 1em;
+}
+

--- a/css/localgov_forms_header_block.css
+++ b/css/localgov_forms_header_block.css
@@ -4,9 +4,10 @@
   margin-bottom: 0.5rem;
 }
 
-.header__form_summary {
-  font-size: 1.375rem!important;
+.header__user_description {
+  font-size: 1.375rem !important;
   font-weight: 400 !important;
+  line-height: 1.5rem;
   margin-bottom: 1em;
 }
 
@@ -24,4 +25,3 @@
   border-top: 1px solid #e0e0e0;
   border-bottom: 1px solid #e0e0e0;
 }
-.

--- a/localgov_forms.libraries.yml
+++ b/localgov_forms.libraries.yml
@@ -32,3 +32,9 @@ localgov_forms.address_change:
     - core/drupal
     - core/once
     - core/jquery
+
+localgov_forms.form_header_block:
+  version: VERSION
+  css:
+    theme:
+      css/localgov_forms_header_block.css: {}

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\Element;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_theme().
@@ -19,6 +20,16 @@ function localgov_forms_theme() {
     // Form element: webform_uk_address.
     'localgov_forms_uk_address' => [
       'render element' => 'element',
+    ],
+    // Form header block.
+    'localgov_forms_form_header_block' => [
+      'variables' => [
+        'formTitle' => '',
+        'wizardPageTitle' => '',
+        'currentPage' => '',
+        'formSummary' => '',
+      ],
+      'render element' => 'block',
     ],
   ];
 }
@@ -54,4 +65,13 @@ function template_preprocess_localgov_forms_uk_address(array &$variables) {
  */
 function localgov_forms_preprocess_webform(array &$variables) {
   $variables['#attached']['library'][] = 'localgov_forms/localgov_forms.form_errors';
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_forms_webform_submission_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  // Assuming you have an instance of FormHeaderBlock.
+  $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
+  $form['form_header_block'] = $form_header_block->build($form_state);
 }

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -7,7 +7,7 @@
 
 use Drupal\Core\Render\Element;
 use Drupal\Core\Form\FormStateInterface;
-
+use Drupal\webform\WebformSubmissionInterface;
 /**
  * Implements hook_theme().
  */
@@ -73,15 +73,83 @@ function localgov_forms_preprocess_webform(array &$variables) {
 function localgov_forms_webform_submission_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   // Check if this is a webform submission form.
   if (strpos($form_id, 'webform_submission_') === 0) {
-    // Assuming you have an instance of FormHeaderBlock.
-    $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
-    // Build the block.
-    $block_build = $form_header_block->build($form_state);
+    // Get the webform.
+    $webform = $form_state->getFormObject()->getWebform();
+    // Check if the form header block is enabled.
+    if ($webform->getThirdPartySetting('localgov_forms', 'display_header_block', FALSE)) {
+      // Assuming you have an instance of FormHeaderBlock.
+      $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
+      // Build the block.
+      $block_build = $form_header_block->build($form_state);
 
-    // Check if the block has content to render.
-    if (!empty($block_build)) {
-      // Add the block as a prefix to the form.
-      $form['#prefix'] = \Drupal::service('renderer')->render($block_build);
+      // Check if the block has content to render.
+      if (!empty($block_build)) {
+        // Add the block as a prefix to the form.
+        $form['#prefix'] = \Drupal::service('renderer')->render($block_build);
+      }
     }
   }
+}
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_forms_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  // Check if this is a webform edit form.
+  if (strpos($form_id, 'webform_settings_form') === 0) {
+    // Get the webform.
+    $webform = $form_state->getFormObject()->getEntity();
+
+    // Add the "User Description" field.
+    $form['settings']['user_description'] = [
+      '#type' => 'textarea',
+      '#title' => t('User Description'),
+      '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'user_description', ''),
+      '#description' => t('A description of this webform for users.'),
+      '#weight' => 10, // Adjust weight as needed.
+    ];
+
+    $form['settings']['display_header_block'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Display Form Header Block'),
+      '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'display_header_block', TRUE),
+      '#description' => t('Enable to display the header block on this webform.'),
+      '#weight' => 10, // Adjust weight as needed.
+    ];
+
+    // Add a submit handler to save the setting.
+    $form['actions']['submit']['#submit'][] = 'localgov_forms_webform_settings_form_submit';
+  }
+    // Check if this is a webform submission form.
+    elseif (strpos($form_id, 'webform_submission_') === 0) {
+      // Get the webform.
+      $webform = $form_state->getFormObject()->getWebform();
+      // Check if the form header block is enabled.
+      if ($webform->getThirdPartySetting('localgov_forms', 'display_header_block', FALSE)) {
+        // Store the form state in the form.
+        $form['#form_state'] = $form_state;
+      }
+    }
+  }
+
+
+/**
+ * Submit handler for webform edit form.
+ */
+function localgov_forms_webform_settings_form_submit(array &$form, FormStateInterface $form_state) {
+  // Get the webform.
+  $webform = $form_state->getFormObject()->getEntity();
+
+  // Get the checkbox value.
+  $enable_form_header_block = $form_state->getValue('display_header_block');
+
+  // Save the setting to the webform.
+  $webform->setThirdPartySetting('localgov_forms', 'display_header_block', $enable_form_header_block);
+  $webform->save();
+
+  // Get the user description value.
+  $user_description = $form_state->getValue('user_description');
+
+  // Save the setting to the webform.
+  $webform->setThirdPartySetting('localgov_forms', 'user_description', $user_description);
+  $webform->save();
 }

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -68,7 +68,7 @@ function localgov_forms_preprocess_webform(array &$variables) {
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
 function localgov_forms_webform_submission_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   // Check if this is a webform submission form.

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -7,7 +7,7 @@
 
 use Drupal\Core\Render\Element;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\webform\WebformSubmissionInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -90,6 +90,7 @@ function localgov_forms_webform_submission_form_alter(array &$form, FormStateInt
     }
   }
 }
+
 /**
  * Implements hook_form_alter().
  */
@@ -111,7 +112,8 @@ function localgov_forms_form_alter(array &$form, FormStateInterface $form_state,
       '#title' => t('User Description'),
       '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'user_description', ''),
       '#description' => t('A usasge description for this form that is shown to users.'),
-      '#weight' => 10, // Adjust weight as needed.
+    // Adjust weight as needed.
+      '#weight' => 10,
     ];
 
     $form['form_settings']['form_header_block_settings']['display_header_block'] = [
@@ -119,24 +121,24 @@ function localgov_forms_form_alter(array &$form, FormStateInterface $form_state,
       '#title' => t('Display Form Header Block'),
       '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'display_header_block', TRUE),
       '#description' => t('Enable the form header block to be displayed on this webform.'),
-      '#weight' => 1, // Adjust weight as needed.
+    // Adjust weight as needed.
+      '#weight' => 1,
     ];
 
     // Add a submit handler to save the setting.
     $form['actions']['submit']['#submit'][] = 'localgov_forms_webform_settings_form_submit';
   }
-    // Check if this is a webform submission form.
-    elseif (strpos($form_id, 'webform_submission_') === 0) {
-      // Get the webform.
-      $webform = $form_state->getFormObject()->getWebform();
-      // Check if the form header block is enabled.
-      if ($webform->getThirdPartySetting('localgov_forms', 'display_header_block', FALSE)) {
-        // Store the form state in the form.
-        $form['#form_state'] = $form_state;
-      }
+  // Check if this is a webform submission form.
+  elseif (strpos($form_id, 'webform_submission_') === 0) {
+    // Get the webform.
+    $webform = $form_state->getFormObject()->getWebform();
+    // Check if the form header block is enabled.
+    if ($webform->getThirdPartySetting('localgov_forms', 'display_header_block', FALSE)) {
+      // Store the form state in the form.
+      $form['#form_state'] = $form_state;
     }
+  }
 }
-
 
 /**
  * Submit handler for webform edit form.

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -75,7 +75,7 @@ function localgov_forms_webform_submission_form_alter(array &$form, FormStateInt
   if (strpos($form_id, 'webform_submission_') === 0) {
     // Get the webform.
     $webform = $form_state->getFormObject()->getWebform();
-    // Check if the form header block is enabled.
+    // Check if the form header block configuration  is enabled.
     if ($webform->getThirdPartySetting('localgov_forms', 'display_header_block', FALSE)) {
       // Assuming you have an instance of FormHeaderBlock.
       $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
@@ -99,21 +99,27 @@ function localgov_forms_form_alter(array &$form, FormStateInterface $form_state,
     // Get the webform.
     $webform = $form_state->getFormObject()->getEntity();
 
+    $form['form_settings']['form_header_block_settings'] = [
+      '#type' => 'details',
+      '#title' => t('Form header settings'),
+      '#open' => TRUE,
+      '#weight' => -9999,
+    ];
     // Add the "User Description" field.
-    $form['settings']['user_description'] = [
+    $form['form_settings']['form_header_block_settings']['user_description'] = [
       '#type' => 'textarea',
       '#title' => t('User Description'),
       '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'user_description', ''),
-      '#description' => t('A description of this webform for users.'),
+      '#description' => t('A usasge description for this form that is shown to users.'),
       '#weight' => 10, // Adjust weight as needed.
     ];
 
-    $form['settings']['display_header_block'] = [
+    $form['form_settings']['form_header_block_settings']['display_header_block'] = [
       '#type' => 'checkbox',
       '#title' => t('Display Form Header Block'),
       '#default_value' => $webform->getThirdPartySetting('localgov_forms', 'display_header_block', TRUE),
-      '#description' => t('Enable to display the header block on this webform.'),
-      '#weight' => 10, // Adjust weight as needed.
+      '#description' => t('Enable the form header block to be displayed on this webform.'),
+      '#weight' => 1, // Adjust weight as needed.
     ];
 
     // Add a submit handler to save the setting.
@@ -129,7 +135,7 @@ function localgov_forms_form_alter(array &$form, FormStateInterface $form_state,
         $form['#form_state'] = $form_state;
       }
     }
-  }
+}
 
 
 /**
@@ -149,7 +155,7 @@ function localgov_forms_webform_settings_form_submit(array &$form, FormStateInte
   // Get the user description value.
   $user_description = $form_state->getValue('user_description');
 
-  // Save the setting to the webform.
+  // Save the user description setting to the webform.
   $webform->setThirdPartySetting('localgov_forms', 'user_description', $user_description);
   $webform->save();
 }

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -27,7 +27,7 @@ function localgov_forms_theme() {
         'formTitle' => '',
         'wizardPageTitle' => '',
         'currentPage' => '',
-        'formSummary' => '',
+        'userDescription' => '',
       ],
       'render element' => 'block',
     ],

--- a/localgov_forms.module
+++ b/localgov_forms.module
@@ -71,7 +71,17 @@ function localgov_forms_preprocess_webform(array &$variables) {
  * Implements hook_form_alter().
  */
 function localgov_forms_webform_submission_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  // Assuming you have an instance of FormHeaderBlock.
-  $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
-  $form['form_header_block'] = $form_header_block->build($form_state);
+  // Check if this is a webform submission form.
+  if (strpos($form_id, 'webform_submission_') === 0) {
+    // Assuming you have an instance of FormHeaderBlock.
+    $form_header_block = \Drupal::service('plugin.manager.block')->createInstance('localgov_forms_form_header_block', []);
+    // Build the block.
+    $block_build = $form_header_block->build($form_state);
+
+    // Check if the block has content to render.
+    if (!empty($block_build)) {
+      // Add the block as a prefix to the form.
+      $form['#prefix'] = \Drupal::service('renderer')->render($block_build);
+    }
+  }
 }

--- a/src/Event/FormHeaderDisplayEvent.php
+++ b/src/Event/FormHeaderDisplayEvent.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Drupal\localgov_forms\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+
+
+/**
+ * Event that is fired when displaying the page header.
+ */
+class FormHeaderDisplayEvent extends Event {
+
+  const EVENT_NAME = 'localgov_forms.form_header_display';
+
+  /**
+   * Entity associated with the current route.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface|null
+   */
+  protected $entity = NULL;
+
+  /**
+   * The form title override.
+   *
+   * @var array|string|null
+   */
+  protected $formTitle = NULL;
+
+  /**
+   * The wizard page title override.
+   *
+   * @var array|string|null
+   */
+  protected $wizardPageTitle = NULL;
+
+  /**
+   * The current page title override.
+   *
+   * @var array|string|null
+   */
+  protected $currentPage = NULL;
+
+  /**
+   * The current page title override.
+   *
+   * @var array|string|null
+   */
+  protected $page_index = NULL;
+
+  /**
+   * The Form Summary override.
+   *
+   * @var array|string|null
+   */
+  protected $formSummary = NULL;
+
+
+  /**
+   * Should the page header block be displayed?
+   *
+   * @var bool
+   */
+  protected $visibility = TRUE;
+
+  /**
+   * Cache tags override.
+   *
+   * @var array|null
+   */
+  protected $cacheTags = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($entity) {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Entity getter.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The entity.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Form Title getter.
+   *
+   * @return array|string|null
+   *   The form title
+   */
+  public function getFormTitle() {
+    return $this->formTitle;
+  }
+
+  /**
+   * Form Title setter.
+   *
+   * @param array|string|null $formTitle
+   *   The form title
+   */
+  public function setFormTitle($form_title) {
+    $this->formTitle = $form_title;
+  }
+
+
+
+  /**
+   * Wizard Page Title getter.
+   *
+   * @return array|string|null
+   *   The title.
+   */
+  public function getWizardPageTitle() {
+    return $this->wizardPageTitle;
+  }
+
+  /**
+   * Wizard Page Title setter.
+   *
+   * @param array|string|null $wizard_page_title
+   *   The title.
+   */
+  public function setWizardPageTitle($wizard_page_title) {
+    $this->wizardPageTitle = $wizard_page_title;
+  }
+
+  /**
+   * Current page getter.
+   *
+   * @return array|string|null
+   *   The current page title.
+   */
+  public function getCurrentPage() {
+    return $this->currentPage;
+  }
+
+  /**
+   * Current page setter.
+   *
+   * @param array|string|null $current_page
+   *   The current page title.
+   */
+  public function setCurrentPage($current_page) {
+    $this->currentPage = $current_page;
+  }
+
+    /**
+   * Form Summary getter.
+   *
+   * @return array|string|null
+   *   The form title
+   */
+  public function getFormSummary() {
+    return $this->formSummary;
+  }
+
+  /**
+   * Form Summary setter.
+   *
+   * @param array|string|null $formSummary
+   *   The form title
+   */
+  public function setFormSummary($form_summary) {
+    $this->formSummary = $form_summary;
+  }
+
+  /**
+   * Visibility getter.
+   *
+   * @return bool|null
+   *   The title.
+   */
+  public function getVisibility() {
+    return $this->visibility;
+  }
+
+  /**
+   * Visibility setter.
+   *
+   * @param bool $visibility
+   *   The visibility.
+   */
+  public function setVisibility($visibility) {
+    $this->visibility = $visibility;
+  }
+
+  /**
+   * Cache tags getter.
+   *
+   * @return array|null
+   *   Cache tags array if set.
+   */
+  public function getCacheTags() {
+    return $this->cacheTags;
+  }
+
+  /**
+   * Cache tags setter.
+   *
+   * @param array $cacheTags
+   *   The cache tags.
+   */
+  public function setCacheTags(array $cacheTags) {
+    $this->cacheTags = $cacheTags;
+  }
+
+}

--- a/src/Event/FormHeaderDisplayEvent.php
+++ b/src/Event/FormHeaderDisplayEvent.php
@@ -48,11 +48,11 @@ class FormHeaderDisplayEvent extends Event {
   protected $page_index = NULL;
 
   /**
-   * The Form Summary override.
+   * The Form user Description override.
    *
    * @var array|string|null
    */
-  protected $formSummary = NULL;
+  protected $userDescription = NULL;
 
 
   /**
@@ -148,14 +148,14 @@ class FormHeaderDisplayEvent extends Event {
     $this->currentPage = $current_page;
   }
 
-    /**
-   * Form Summary getter.
+  /**
+   * Form User Description getter.
    *
    * @return array|string|null
-   *   The form title
+   *   The User description title
    */
-  public function getFormSummary() {
-    return $this->formSummary;
+  public function getFormUserDescription() {
+    return $this->userDescription;
   }
 
   /**
@@ -165,7 +165,7 @@ class FormHeaderDisplayEvent extends Event {
    *   The form title
    */
   public function setFormSummary($form_summary) {
-    $this->formSummary = $form_summary;
+    $this->userDescription = $form_summary;
   }
 
   /**

--- a/src/Event/FormHeaderDisplayEvent.php
+++ b/src/Event/FormHeaderDisplayEvent.php
@@ -4,7 +4,6 @@ namespace Drupal\localgov_forms\Event;
 
 use Drupal\Component\EventDispatcher\Event;
 
-
 /**
  * Event that is fired when displaying the page header.
  */
@@ -45,7 +44,7 @@ class FormHeaderDisplayEvent extends Event {
    *
    * @var array|string|null
    */
-  protected $page_index = NULL;
+  protected $pageIndex = NULL;
 
   /**
    * The Form user Description override.
@@ -100,13 +99,11 @@ class FormHeaderDisplayEvent extends Event {
    * Form Title setter.
    *
    * @param array|string|null $formTitle
-   *   The form title
+   *   The form title.
    */
-  public function setFormTitle($form_title) {
-    $this->formTitle = $form_title;
+  public function setFormTitle($formTitle) {
+    $this->formTitle = $formTitle;
   }
-
-
 
   /**
    * Wizard Page Title getter.
@@ -161,8 +158,8 @@ class FormHeaderDisplayEvent extends Event {
   /**
    * Form Summary setter.
    *
-   * @param array|string|null $formSummary
-   *   The form title
+   * @param array|string|null $form_summary
+   *   The form summary.
    */
   public function setFormSummary($form_summary) {
     $this->userDescription = $form_summary;

--- a/src/EventSubscriber/FormHeaderSubscriber.php
+++ b/src/EventSubscriber/FormHeaderSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\localgov_forms\EventSubscriber;
+
+use Drupal\localgov_forms\Event\FormHeaderDisplayEvent;
+use Drupal\webform\WebformInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Hide page header.
+ *
+ * @package Drupal\localgov_forms\EventSubscriber
+ */
+class FormHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      FormHeaderDisplayEvent::EVENT_NAME => ['setFormHeader', 0],
+    ];
+  }
+
+  /**
+   * Hide page header block.
+   */
+  public function setFormHeader(FormHeaderDisplayEvent $event) {
+    if ($event->getEntity() instanceof WebformInterface &&
+      ($event->getEntity()->bundle() == 'localgov_forms_overview' ||
+      $event->getEntity()->bundle() == 'localgov_forms_page')
+    ) {
+      $event->setVisibility(FALSE);
+    }
+  }
+
+}

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -102,7 +102,6 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $container->get('title_resolver')
     );
   }
-
   public function build(FormStateInterface $form_state = NULL) {;
 
     $build = [];
@@ -120,21 +119,22 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $page_title = $wizard_pages[$currentPage]["#title"];
       $this->wizardPageTitle = $page_title;
 
+      $build = [
+        '#theme' => 'localgov_forms_form_header_block',
+        '#formTitle' => $this->formTitle,
+        '#wizardPageTitle' => $this->wizardPageTitle,
+        '#currentPage' => $this->currentPage,
+        '#formSummary' => $this->formSummary,
+        '#cache' => [
+          'max-age' => 0,
+        ],
+      ];
     }
-
-    $build[] = [
-      '#theme' => 'localgov_forms_form_header_block',
-      '#formTitle' => $this->formTitle,
-      '#wizardPageTitle' => $this->wizardPageTitle,
-      '#currentPage' => $this->currentPage,
-      '#formSummary' => $this->formSummary,
-      '#cache' => [
-        'max-age' => 0,
-      ],
-    ];
 
     return $build;
   }
+
+
 
   protected function getFormTitle() {
     $request = $this->requestStack->getCurrentRequest();

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -128,12 +128,16 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
         '#cache' => [
           'max-age' => 0,
         ],
+        '#attached' => [
+          'library' => [
+            'localgov_forms/localgov_forms.form_header_block',
+          ],
+        ],
       ];
     }
 
     return $build;
   }
-
 
 
   protected function getFormTitle() {
@@ -146,8 +150,6 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   protected function getCurrentPage() {
-
-
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
 
       $wizard_pages = $this->entity->getPages();

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -15,7 +15,6 @@ use Drupal\localgov_forms\Event\FormHeaderDisplayEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\webform\WebformInterface;
-use Drupal\webform\WebformSubmissionInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -81,16 +80,19 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $this->eventDispatcher->dispatch($event, FormHeaderDisplayEvent::EVENT_NAME);
 
     // Set the Form title, current page, form summary, visibility and cache tags.
-    $this->formTitle = $event->getFormTitle() === NULL ? $this->getFormTitle() : $event->getFormTitle();
-    $this->currentPage = $event->getCurrentPage() === NULL ? $this->getCurrentPage() : $event->getCurrentPage();//
-    $this->wizardPageTitle = $event->getWizardPageTitle() === NULL ? $this->getWizardPageTitle() : $event->getWizardPageTitle();
-    $this->formSummary = $event->getFormSummary() === NULL ? $this->getFormSummary() : $event->getFormSummary();
+    $this->formTitle = $event->getFormTitle() ?? $this->getFormTitle();
+    $this->currentPage = $event->getCurrentPage() ?? $this->getCurrentPage();
+    $this->wizardPageTitle = $event->getWizardPageTitle() ?? $this->getWizardPageTitle();
+    $this->formSummary = $event->getFormSummary() ?? $this->getFormSummary();
     $this->visible = $event->getVisibility();
 
     $entityCacheTags = $this->entity === NULL ? [] : $this->entity->getCacheTags();
-    $this->cacheTags = $event->getCacheTags() === NULL ? $entityCacheTags : $event->getCacheTags();
+    $this->cacheTags = $event->getCacheTags() ?? $entityCacheTags;
   }
 
+  /**
+   *
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration,
@@ -102,7 +104,12 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $container->get('title_resolver')
     );
   }
-  public function build(FormStateInterface $form_state = NULL) {;
+
+  /**
+   *
+   */
+  public function build(?FormStateInterface $form_state = NULL) {
+    ;
 
     $build = [];
 
@@ -113,7 +120,7 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $page_keys = array_keys($wizard_pages);
 
       // Add the form title to the beginning of the array.
-      // so that page indexes start from 1
+      // so that page indexes start from 1.
       array_unshift($page_keys, $this->formTitle);
 
       $page_title = $wizard_pages[$currentPage]["#title"];
@@ -139,7 +146,9 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return $build;
   }
 
-
+  /**
+   *
+   */
   protected function getFormTitle() {
     $request = $this->requestStack->getCurrentRequest();
     $route = $this->currentRouteMatch->getRouteObject();
@@ -149,6 +158,9 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return NULL;
   }
 
+  /**
+   *
+   */
   protected function getCurrentPage() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
 
@@ -170,6 +182,10 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     }
     return NULL;
   }
+
+  /**
+   *
+   */
   protected function getWizardPageTitle() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
       $currentPage = $this->currentPage;
@@ -177,7 +193,7 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $page_keys = array_keys($wizard_pages);
 
       // Add the form title to the beginning of the array.
-      // so that page indexes start from 1
+      // so that page indexes start from 1.
       array_unshift($page_keys, $this->formTitle);
 
       $page_title = isset($page_keys[$currentPage]) ? $wizard_pages[$page_keys[$currentPage]]["#title"] : NULL;
@@ -187,14 +203,20 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return NULL;
   }
 
+  /**
+   *
+   */
   protected function getFormSummary() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
-      // return $this->entity->getDescription();
+      // Return $this->entity->getDescription();
       return $this->entity->getThirdPartySetting('localgov_forms', 'user_description');
     }
     return NULL;
   }
 
+  /**
+   *
+   */
   protected function blockAccess(AccountInterface $account) {
     if ($this->visible) {
       return AccessResult::allowed();
@@ -204,10 +226,16 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     }
   }
 
+  /**
+   *
+   */
   public function defaultConfiguration() {
     return ['label_display' => FALSE];
   }
 
+  /**
+   *
+   */
   public function getCacheTags() {
     if (!empty($this->cacheTags)) {
       return Cache::mergeTags(parent::getCacheTags(), $this->cacheTags);
@@ -215,7 +243,11 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return parent::getCacheTags();
   }
 
+  /**
+   *
+   */
   public function getCacheContexts() {
     return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
   }
+
 }

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -189,7 +189,8 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
 
   protected function getFormSummary() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
-      return $this->entity->getDescription();
+      // return $this->entity->getDescription();
+      return $this->entity->getThirdPartySetting('localgov_forms', 'user_description');
     }
     return NULL;
   }

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -27,19 +27,140 @@ use Drupal\Core\Form\FormStateInterface;
  */
 class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
+  /**
+   * The current route match service.
+   *
+   * This service provides information about
+   * the current route and its parameters.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
   protected $currentRouteMatch;
+
+  /**
+   * The event dispatcher service.
+   *
+   * This service is used to dispatch events within the application.
+   *
+   * @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
+   */
   protected $eventDispatcher;
+
+  /**
+   * The request stack service.
+   *
+   * This service provides access to the current request and allows
+   * interaction with the request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
   protected $requestStack;
+
+  /**
+   * The title resolver service.
+   *
+   * This service is used to resolve the title for the form header block.
+   *
+   * @var \Drupal\Core\TitleResolverInterface
+   */
   protected $titleResolver;
+
+  /**
+   * The entity associated with the form header block.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface|null
+   *   The entity object or NULL if no entity is set.
+   */
   protected $entity = NULL;
+
+  /**
+   * The title of the form.
+   *
+   * @var string
+   */
   protected $formTitle;
+
+  /**
+   * The current page object.
+   *
+   * This property holds the current page context, which can be used to
+   * determine the page-specific information or behavior.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface|null
+   */
   protected $currentPage;
+
+  /**
+   * The title of the current wizard page.
+   *
+   * This property stores the title of the page in a multi-step form wizard.
+   *
+   * @var string
+   */
   protected $wizardPageTitle;
-  protected $formSummary;
+
+  /**
+   * The summary of the form.
+   *
+   * This property holds a brief description or summary of the form
+   * associated with this block.
+   *
+   * @var string
+   */
+  protected $userDescription;
+
+  /**
+   * Indicates whether the form header block is visible.
+   *
+   * @var bool
+   */
   protected $visible;
+
+  /**
+   * The cache tags associated with this block.
+   *
+   * Cache tags are used to manage cache invalidation for this block.
+   *
+   * @var array
+   */
   protected $cacheTags;
+
+  /**
+   * The form state service.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface
+   */
   protected $formState;
 
+  /**
+   * Constructs a FormHeaderBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $current_route_match
+   *   The current route match service.
+   * @param \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher $event_dispatcher
+   *   The event dispatcher service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
+   * @param \Drupal\Core\Render\TitleResolver $title_resolver
+   *   The title resolver service.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown if the entity associated with the current route is invalid.
+   *
+   *   This constructor initializes the block by:
+   *   - Determining the entity associated with the current route, if any.
+   *   - Dispatching a FormHeaderDisplayEvent to allow modules
+   *    to alter block content.
+   *   - Setting the form title, current page, wizard page title,
+   *    user description,
+   *    visibility, and cache tags based on the event or default values.
+   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $current_route_match, ContainerAwareEventDispatcher $event_dispatcher, RequestStack $request_stack, TitleResolver $title_resolver) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->currentRouteMatch = $current_route_match;
@@ -79,11 +200,12 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $event = new FormHeaderDisplayEvent($this->entity);
     $this->eventDispatcher->dispatch($event, FormHeaderDisplayEvent::EVENT_NAME);
 
-    // Set the Form title, current page, form summary, visibility and cache tags.
+    // Set the Form title, current page, form summary,
+    // visibility and cache tags.
     $this->formTitle = $event->getFormTitle() ?? $this->getFormTitle();
     $this->currentPage = $event->getCurrentPage() ?? $this->getCurrentPage();
     $this->wizardPageTitle = $event->getWizardPageTitle() ?? $this->getWizardPageTitle();
-    $this->formSummary = $event->getFormSummary() ?? $this->getFormSummary();
+    $this->userDescription = $event->getFormUserDescription() ?? $this->getFormUserDescription();
     $this->visible = $event->getVisibility();
 
     $entityCacheTags = $this->entity === NULL ? [] : $this->entity->getCacheTags();
@@ -91,28 +213,51 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Creates an instance of the FormHeaderBlock plugin.
    *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The service container.
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   *
+   * @return static
+   *   Returns a new instance of the FormHeaderBlock plugin.
+   *
+   * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+   *   Thrown if a required service is not found in the container.
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('current_route_match'),
-      $container->get('event_dispatcher'),
-      $container->get('request_stack'),
-      $container->get('title_resolver')
+    $configuration,
+    $plugin_id,
+    $plugin_definition,
+    $container->get('current_route_match'),
+    $container->get('event_dispatcher'),
+    $container->get('request_stack'),
+    $container->get('title_resolver')
     );
   }
 
   /**
+   * Summary of build.
    *
+   * @param mixed $form_state
+   *   The form state object.
+   *
+   * @return array|array{#attached: array,
+   *   #cache: array{max-age: int,
+   *   #currentPage: \Drupal\Core\Routing\RouteMatchInterface|null,
+   *   #formTitle: string,
+   *   #theme: string, #userDescription: string,
+   *   #wizardPageTitle: string
+   *   }}
    */
   public function build(?FormStateInterface $form_state = NULL) {
-    ;
-
     $build = [];
-
     if ($form_state) {
       $this->currentPage = $form_state->get('current_page');
       $currentPage = $this->currentPage;
@@ -131,7 +276,7 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
         '#formTitle' => $this->formTitle,
         '#wizardPageTitle' => $this->wizardPageTitle,
         '#currentPage' => $this->currentPage,
-        '#formSummary' => $this->formSummary,
+        '#userDescription' => $this->userDescription,
         '#cache' => [
           'max-age' => 0,
         ],
@@ -142,12 +287,18 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
         ],
       ];
     }
-
     return $build;
   }
 
   /**
+   * Retrieves the title of the current form.
    *
+   * This method uses the current request and route to resolve the title
+   * of the form. If a route is available, the title is resolved using
+   * the title resolver service. If no route is found, it returns NULL.
+   *
+   * @return string|null
+   *   The resolved title of the form, or NULL if no route is available.
    */
   protected function getFormTitle() {
     $request = $this->requestStack->getCurrentRequest();
@@ -159,7 +310,16 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Retrieves the current page index of a webform with wizard pages.
    *
+   * This method checks if the current entity is a webform with wizard pages.
+   * If so, it retrieves the list of wizard pages and determines the current
+   * page index based on the request query parameter 'page'. If the 'page'
+   * parameter is not set, it defaults to the first page in the wizard.
+   *
+   * @return string|int|null
+   *   The current page index if available, or NULL if the entity is not a
+   *   webform with wizard pages or if no page index is determined.
    */
   protected function getCurrentPage() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
@@ -184,7 +344,17 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Retrieves the title of the current wizard page in a webform.
    *
+   * This method checks if the associated entity is a webform with wizard pages.
+   * If so, it determines the title of the current page based on the wizard's
+   * page structure. The form title is prepended to the page keys to ensure
+   * page indexes start from 1.
+   *
+   * @return string|null
+   *   The title of the current wizard page, or NULL if the entity is not a
+   *   webform with wizard pages or if the current page title cannot be
+   *   determined.
    */
   protected function getWizardPageTitle() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
@@ -204,9 +374,18 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Retrieves the user description for the form.
    *
+   * This method checks if the current entity is a webform with wizard pages.
+   * If so, it retrieves the user description from the third-party settings
+   * specific to the "localgov_forms" module. If the conditions are not met,
+   * it returns NULL.
+   *
+   * @return string|null
+   *   The user description from the third-party settings, or NULL if the
+   *   entity is not a webform with wizard pages or the description is not set.
    */
-  protected function getFormSummary() {
+  protected function getFormUserDescription() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
       // Return $this->entity->getDescription();
       return $this->entity->getThirdPartySetting('localgov_forms', 'user_description');
@@ -215,7 +394,14 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Determines access to the block based on its visibility.
    *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account object for which access is being checked.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Returns AccessResult::allowed() if the block is visible,
+   *   otherwise returns AccessResult::neutral().
    */
   protected function blockAccess(AccountInterface $account) {
     if ($this->visible) {
@@ -227,14 +413,26 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * Provides the default configuration for the block.
    *
+   * @return array
+   *   An associative array containing the default configuration values:
+   *   - label_display: (bool) Whether the label should be displayed.
+   *   Defaults to FALSE.
    */
   public function defaultConfiguration() {
     return ['label_display' => FALSE];
   }
 
   /**
+   * Retrieves the cache tags associated with this block.
    *
+   * This method checks if additional cache tags are defined for the block
+   * and merges them with the parent cache tags. If no additional cache tags
+   * are defined, it simply returns the parent cache tags.
+   *
+   * @return array
+   *   An array of cache tags.
    */
   public function getCacheTags() {
     if (!empty($this->cacheTags)) {
@@ -244,7 +442,15 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
+   * {@inheritdoc}
    *
+   * Overrides the cache contexts for the block.
+   * Adds the 'route' cache context to ensure the block is cached
+   * per route, in addition to the default cache contexts provided
+   * by the parent implementation.
+   *
+   * @return array
+   *   An array of cache contexts.
    */
   public function getCacheContexts() {
     return Cache::mergeContexts(parent::getCacheContexts(), ['route']);

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Drupal\localgov_forms\Plugin\Block;
+
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Controller\TitleResolver;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\localgov_forms\Event\FormHeaderDisplayEvent;
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\webform\WebformInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\Core\Form\FormStateInterface;
+/**
+ * Provides a 'FormHeaderBlock' block.
+ *
+ * @Block(
+ *  id = "localgov_forms_form_header_block",
+ *  admin_label = @Translation("Form header block"),
+ * )
+ */
+class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Core current_route_match service.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Core event_dispatcher service.
+   *
+   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   */
+  protected $eventDispatcher;
+
+  /**
+   * Core request_stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Core title_resolver service.
+   *
+   * @var \Drupal\Core\Controller\TitleResolver
+   */
+  protected $titleResolver;
+
+  /**
+   * Entity associated with the current route.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface|null
+   */
+  protected $entity = NULL;
+
+  /**
+   * The form title override.
+   *
+   * @var array|string|null
+   */
+  protected $formTitle;
+
+
+  /**
+   * The current page title override.
+   *
+   * @var array|string|null
+   */
+  protected $currentPage;
+
+  /**
+   * The wizard page title override.
+   *
+   * @var array|string|null
+   */
+  protected $wizardPageTitle;
+
+    /**
+   * The form Summaryoverride.
+   *
+   * @var array|string|null
+   */
+  protected $formSummary;
+
+  /**
+   * Should the page header block be displayed?
+   *
+   * @var bool
+   */
+  protected $visible;
+
+  /**
+   * Cache tags for this block.
+   *
+   * @var array
+   */
+  protected $cacheTags;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('event_dispatcher'),
+      $container->get('request_stack'),
+      $container->get('title_resolver')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $current_route_match, ContainerAwareEventDispatcher $event_dispatcher, RequestStack $request_stack, TitleResolver $title_resolver) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->currentRouteMatch = $current_route_match;
+    $this->eventDispatcher = $event_dispatcher;
+    $this->requestStack = $request_stack;
+    $this->titleResolver = $title_resolver;
+
+    // Find the entity, if any, associated with the current route.
+    //
+    // We consider two cases: (1) type entity:*, and (2) type node_preview with
+    // view_mode_id set to 'full'.
+    $route = $this->currentRouteMatch->getRouteObject();
+    if (!is_null($route)) {
+      $parameters = $route->getOption('parameters');
+      if (!is_null($parameters)) {
+        foreach ($parameters as $name => $options) {
+          if (!isset($options['type'])) {
+            continue;
+          }
+
+          if (strpos($options['type'], 'entity:') === 0) {
+            $entity = $this->currentRouteMatch->getParameter($name);
+          }
+          elseif ($options['type'] === 'node_preview') {
+            $preview = $this->currentRouteMatch->getParentRouteMatch()->getParameter($name);
+            if (isset($preview->preview_view_mode) && $preview->preview_view_mode === 'full') {
+              $entity = $preview;
+            }
+          }
+
+          if (isset($entity) && $entity instanceof EntityInterface) {
+            $this->entity = $entity;
+            break;
+          }
+        }
+      }
+    }
+
+    // Dispatch event to allow modules to alter block content.
+    $event = new FormHeaderDisplayEvent($this->entity);
+    $this->eventDispatcher->dispatch($event, FormHeaderDisplayEvent::EVENT_NAME);
+
+    // Set the Form title, current page, form summary, visibility and cache tags.
+    $this->formTitle = is_null($event->getFormTitle()) ? $this->getFormTitle() : $event->getFormTitle();
+    $this->currentPage = is_null($event->getCurrentPage()) ? $this->getCurrentPage() : $event->getCurrentPage();
+    $this->wizardPageTitle = is_null($event->getWizardPageTitle()) ? $this->getWizardPageTitle() : $event->getWizardPageTitle();
+    $this->formSummary = is_null($event->getFormSummary()) ? $this->getFormSummary() : $event->getFormSummary();
+    $this->visible = $event->getVisibility();
+
+    $entityCacheTags = is_null($this->entity) ? [] : $this->entity->getCacheTags();
+    $this->cacheTags = is_null($event->getCacheTags()) ? $entityCacheTags : $event->getCacheTags();
+
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    $build[] = [
+      '#theme' => 'localgov_forms_form_header_block',
+      '#formTitle' => $this->formTitle,
+      '#wizardPageTitle' => $this->wizardPageTitle,
+      '#currentPage' => $this->currentPage,
+      '#formSummary' => $this->formSummary,
+      '#cache' => [
+        'max-age' => 0,
+        ]
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Get the Webform Title.
+   *
+   * @return array|string|null
+   *   Returns a title for the current page or NULL if it can't be determined.
+   */
+  protected function getFormTitle() {
+    $request = $this->requestStack->getCurrentRequest();
+    $route = $this->currentRouteMatch->getRouteObject();
+    if ($route) {
+      return $this->titleResolver->getTitle($request, $route);
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the current page.
+   *
+   * @return array|string|null
+   *   Returns the current page or NULL if it can't be determined.
+   */
+  protected function getCurrentPage() {
+
+    if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
+
+        $wizard_pages =  $this->entity->getPages();
+        $page_keys = array_keys($wizard_pages);
+        // $page_indexes = array_flip($page_keys);
+
+        // Determine the Current Page Index.
+        if (!isset($currentPage)) {
+            $currentPage = reset($page_keys);
+
+        }
+
+      return $currentPage;
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the Wizard Page Title
+   * @return array|string|null
+   *   Returns the current page or NULL if it can't be determined.
+   */
+  protected function getWizardPageTitle(){
+    if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
+
+        // $currentPage = NULL;
+        $currentPage =  $this->currentPage;
+        $wizard_pages =  $this->entity->getPages();
+        $page_keys = array_keys($wizard_pages);
+        // $description = $this->entity->getDescription();
+
+        // $number_of_wizard_pages = $this->entity->getNumberOfWizardPages();
+        // $page_keys = array_keys($wizard_pages);
+        // $page_index = reset($page_keys);
+
+
+        $page_title = $wizard_pages[$currentPage]["#title"];
+
+      return $page_title;
+    }
+  }
+
+  /**
+   * Get the Wizard Page Title
+   * @return array|string|null
+   *   Returns the current page or NULL if it can't be determined.
+   */
+  protected function getFormSummary(){
+    if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
+        $form_summary = $this->entity->getDescription();
+      return $form_summary;
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    if ($this->visible) {
+      return AccessResult::allowed();
+    }
+    else {
+      return AccessResult::neutral();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    if (!empty($this->cacheTags)) {
+      return Cache::mergeTags(parent::getCacheTags(), $this->cacheTags);
+    }
+    return parent::getCacheTags();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
+  }
+
+}

--- a/src/Plugin/Block/FormHeaderBlock.php
+++ b/src/Plugin/Block/FormHeaderBlock.php
@@ -12,14 +12,12 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\localgov_forms\Event\FormHeaderDisplayEvent;
-use Drupal\node\Entity\Node;
-use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
-use Drupal\webform\Entity\WebformSubmission;
 use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Provides a 'FormHeaderBlock' block.
  *
@@ -30,118 +28,31 @@ use Drupal\Core\Form\FormStateInterface;
  */
 class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * Core current_route_match service.
-   *
-   * @var \Drupal\Core\Routing\CurrentRouteMatch
-   */
   protected $currentRouteMatch;
-
-  /**
-   * Core event_dispatcher service.
-   *
-   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
-   */
   protected $eventDispatcher;
-
-  /**
-   * Core request_stack service.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
   protected $requestStack;
-
-  /**
-   * Core title_resolver service.
-   *
-   * @var \Drupal\Core\Controller\TitleResolver
-   */
   protected $titleResolver;
-
-  /**
-   * Entity associated with the current route.
-   *
-   * @var \Drupal\Core\Entity\EntityInterface|null
-   */
   protected $entity = NULL;
-
-  /**
-   * The form title override.
-   *
-   * @var array|string|null
-   */
   protected $formTitle;
-
-
-  /**
-   * The current page title override.
-   *
-   * @var array|string|null
-   */
   protected $currentPage;
-
-  /**
-   * The wizard page title override.
-   *
-   * @var array|string|null
-   */
   protected $wizardPageTitle;
-
-    /**
-   * The form Summaryoverride.
-   *
-   * @var array|string|null
-   */
   protected $formSummary;
-
-  /**
-   * Should the page header block be displayed?
-   *
-   * @var bool
-   */
   protected $visible;
-
-  /**
-   * Cache tags for this block.
-   *
-   * @var array
-   */
   protected $cacheTags;
+  protected $formState;
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('current_route_match'),
-      $container->get('event_dispatcher'),
-      $container->get('request_stack'),
-      $container->get('title_resolver')
-    );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $current_route_match, ContainerAwareEventDispatcher $event_dispatcher, RequestStack $request_stack, TitleResolver $title_resolver) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-
     $this->currentRouteMatch = $current_route_match;
     $this->eventDispatcher = $event_dispatcher;
     $this->requestStack = $request_stack;
     $this->titleResolver = $title_resolver;
 
     // Find the entity, if any, associated with the current route.
-    //
-    // We consider two cases: (1) type entity:*, and (2) type node_preview with
-    // view_mode_id set to 'full'.
     $route = $this->currentRouteMatch->getRouteObject();
-    if (!is_null($route)) {
+    if ($route !== NULL) {
       $parameters = $route->getOption('parameters');
-      if (!is_null($parameters)) {
+      if ($parameters !== NULL) {
         foreach ($parameters as $name => $options) {
           if (!isset($options['type'])) {
             continue;
@@ -170,23 +81,46 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $this->eventDispatcher->dispatch($event, FormHeaderDisplayEvent::EVENT_NAME);
 
     // Set the Form title, current page, form summary, visibility and cache tags.
-    $this->formTitle = is_null($event->getFormTitle()) ? $this->getFormTitle() : $event->getFormTitle();
-    $this->currentPage = is_null($event->getCurrentPage()) ? $this->getCurrentPage() : $event->getCurrentPage();
-    $this->wizardPageTitle = is_null($event->getWizardPageTitle()) ? $this->getWizardPageTitle() : $event->getWizardPageTitle();
-    $this->formSummary = is_null($event->getFormSummary()) ? $this->getFormSummary() : $event->getFormSummary();
+    $this->formTitle = $event->getFormTitle() === NULL ? $this->getFormTitle() : $event->getFormTitle();
+    $this->currentPage = $event->getCurrentPage() === NULL ? $this->getCurrentPage() : $event->getCurrentPage();//
+    $this->wizardPageTitle = $event->getWizardPageTitle() === NULL ? $this->getWizardPageTitle() : $event->getWizardPageTitle();
+    $this->formSummary = $event->getFormSummary() === NULL ? $this->getFormSummary() : $event->getFormSummary();
     $this->visible = $event->getVisibility();
 
-    $entityCacheTags = is_null($this->entity) ? [] : $this->entity->getCacheTags();
-    $this->cacheTags = is_null($event->getCacheTags()) ? $entityCacheTags : $event->getCacheTags();
-
+    $entityCacheTags = $this->entity === NULL ? [] : $this->entity->getCacheTags();
+    $this->cacheTags = $event->getCacheTags() === NULL ? $entityCacheTags : $event->getCacheTags();
   }
 
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('event_dispatcher'),
+      $container->get('request_stack'),
+      $container->get('title_resolver')
+    );
+  }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function build() {
+  public function build(FormStateInterface $form_state = NULL) {;
+
     $build = [];
+
+    if ($form_state) {
+      $this->currentPage = $form_state->get('current_page');
+      $currentPage = $this->currentPage;
+      $wizard_pages = $this->entity->getPages();
+      $page_keys = array_keys($wizard_pages);
+
+      // Add the form title to the beginning of the array.
+      // so that page indexes start from 1
+      array_unshift($page_keys, $this->formTitle);
+
+      $page_title = $wizard_pages[$currentPage]["#title"];
+      $this->wizardPageTitle = $page_title;
+
+    }
 
     $build[] = [
       '#theme' => 'localgov_forms_form_header_block',
@@ -196,18 +130,12 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#formSummary' => $this->formSummary,
       '#cache' => [
         'max-age' => 0,
-        ]
+      ],
     ];
 
     return $build;
   }
 
-  /**
-   * Get the Webform Title.
-   *
-   * @return array|string|null
-   *   Returns a title for the current page or NULL if it can't be determined.
-   */
   protected function getFormTitle() {
     $request = $this->requestStack->getCurrentRequest();
     $route = $this->currentRouteMatch->getRouteObject();
@@ -217,72 +145,53 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return NULL;
   }
 
-  /**
-   * Get the current page.
-   *
-   * @return array|string|null
-   *   Returns the current page or NULL if it can't be determined.
-   */
   protected function getCurrentPage() {
+
 
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
 
-        $wizard_pages =  $this->entity->getPages();
-        $page_keys = array_keys($wizard_pages);
-        // $page_indexes = array_flip($page_keys);
+      $wizard_pages = $this->entity->getPages();
+      $page_keys = array_keys($wizard_pages);
 
-        // Determine the Current Page Index.
-        if (!isset($currentPage)) {
-            $currentPage = reset($page_keys);
+      // Get the current page index from the request.
+      $request = $this->requestStack->getCurrentRequest();
+      $current_page_index = $request->query->get('page');
 
-        }
+      if ($current_page_index !== NULL) {
+        return $current_page_index;
+      }
+      else {
+        $currentPage = reset($page_keys);
+      }
 
       return $currentPage;
     }
     return NULL;
   }
-
-  /**
-   * Get the Wizard Page Title
-   * @return array|string|null
-   *   Returns the current page or NULL if it can't be determined.
-   */
-  protected function getWizardPageTitle(){
+  protected function getWizardPageTitle() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
+      $currentPage = $this->currentPage;
+      $wizard_pages = $this->entity->getPages();
+      $page_keys = array_keys($wizard_pages);
 
-        // $currentPage = NULL;
-        $currentPage =  $this->currentPage;
-        $wizard_pages =  $this->entity->getPages();
-        $page_keys = array_keys($wizard_pages);
-        // $description = $this->entity->getDescription();
+      // Add the form title to the beginning of the array.
+      // so that page indexes start from 1
+      array_unshift($page_keys, $this->formTitle);
 
-        // $number_of_wizard_pages = $this->entity->getNumberOfWizardPages();
-        // $page_keys = array_keys($wizard_pages);
-        // $page_index = reset($page_keys);
-
-
-        $page_title = $wizard_pages[$currentPage]["#title"];
+      $page_title = isset($page_keys[$currentPage]) ? $wizard_pages[$page_keys[$currentPage]]["#title"] : NULL;
 
       return $page_title;
     }
+    return NULL;
   }
 
-  /**
-   * Get the Wizard Page Title
-   * @return array|string|null
-   *   Returns the current page or NULL if it can't be determined.
-   */
-  protected function getFormSummary(){
+  protected function getFormSummary() {
     if ($this->entity instanceof WebformInterface && $this->entity->hasWizardPages()) {
-        $form_summary = $this->entity->getDescription();
-      return $form_summary;
+      return $this->entity->getDescription();
     }
+    return NULL;
   }
 
-
-  /**
-   * {@inheritdoc}
-   */
   protected function blockAccess(AccountInterface $account) {
     if ($this->visible) {
       return AccessResult::allowed();
@@ -292,16 +201,10 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     }
   }
 
-  /**
-   * {@inheritdoc}
-   */
   public function defaultConfiguration() {
     return ['label_display' => FALSE];
   }
 
-  /**
-   * {@inheritdoc}
-   */
   public function getCacheTags() {
     if (!empty($this->cacheTags)) {
       return Cache::mergeTags(parent::getCacheTags(), $this->cacheTags);
@@ -309,11 +212,7 @@ class FormHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     return parent::getCacheTags();
   }
 
-  /**
-   * {@inheritdoc}
-   */
   public function getCacheContexts() {
     return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
   }
-
 }

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -19,9 +19,9 @@
 		{{ formTitle }}
 	</h1>
 
-	{% if formSummary %}
-    <div class="header__form_summary">
-      {{ formSummary|raw }}
+	{% if userDescription %}
+    <div class="header__user_description">
+      {{ userDescription|raw }}
     </div>
 	{% endif %}
 

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -26,7 +26,7 @@
 	{% endif %}
 
 	{% if wizardPageTitle %}
-  <hr>
+  <hr class="header__form_title_hr">
 		<div class="header__wizard_page_title">
       {{ wizardPageTitle }}
     </div>

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -11,25 +11,29 @@
 {% set classes = [
     'clear-both',
     'headers',
-    'key',
 ] %}
 {% if formTitle %}
-<div{{ attributes.addClass(classes) }}>
-  <h1 class="header">
-    {{ formTitle }}
-    {% if wizardPageTitle %}
-      <div class="header__wizard_page_title">{{ wizardPageTitle }}</div>
-    {% endif %}
+<div{{attributes.addClass(classes)}}>
 
-    {% if hasFormErrors %}
-        <div class="header__form_errors">
-          {{ 'There are errors on this page.'|t }}
-        </div>
-    {% endif %}
+	<h1 class="header__form_title">
+		{{ formTitle }}
+	</h1>
 
-  </h1>
-  {% if formSummary %}
-    <div class="header__form_title">{{ formSummary }}</div>
-  {% endif %}
+	{% if formSummary %}
+    <div class="header__form_summary">
+      <h2>
+      {{ formSummary|raw }}
+      </h2>
+    </div>
+	{% endif %}
+
+	{% if wizardPageTitle %}
+  <hr>
+		<div class="header__wizard_page_title">
+      {{ wizardPageTitle }}
+    </div>
+	{% endif %}
+
 </div>
 {% endif %}
+

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -21,9 +21,7 @@
 
 	{% if formSummary %}
     <div class="header__form_summary">
-      <h2>
       {{ formSummary|raw }}
-      </h2>
     </div>
 	{% endif %}
 

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+* @file
+* Default theme implementation of localgov_forms_form_header_block.
+*
+* @see template_preprocess_block()
+*
+* @ingroup themeable
+*/
+#}
+{% set classes = [
+    'clear-both',
+    'headers',
+    'key',
+] %}
+{% if formTitle %}
+<div{{ attributes.addClass(classes) }}>
+  <h1 class="header">
+    {{ formTitle }}
+    {% if wizardPageTitle %}
+      <div class="header__subtitle">{{ wizardPageTitle }}</div>
+    {% endif %}
+  </h1>
+  {% if formSummary %}
+    <div class="subheader">{{ formSummary }}</div>
+  {% endif %}
+</div>
+{% endif %}

--- a/templates/localgov-forms-form-header-block.html.twig
+++ b/templates/localgov-forms-form-header-block.html.twig
@@ -18,11 +18,18 @@
   <h1 class="header">
     {{ formTitle }}
     {% if wizardPageTitle %}
-      <div class="header__subtitle">{{ wizardPageTitle }}</div>
+      <div class="header__wizard_page_title">{{ wizardPageTitle }}</div>
     {% endif %}
+
+    {% if hasFormErrors %}
+        <div class="header__form_errors">
+          {{ 'There are errors on this page.'|t }}
+        </div>
+    {% endif %}
+
   </h1>
   {% if formSummary %}
-    <div class="subheader">{{ formSummary }}</div>
+    <div class="header__form_title">{{ formSummary }}</div>
   {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
## What does this change?
This change adds a form header block, that displays the form's title, description and current page.
This change adds configuration settings - a checkbox to enable or disable the form header section.
This change adds configuration settings - a textarea field where a form usage description can be added.

When enabled in an individual webform's general settings, we prefix the webform with a
custom block that serves as a 'Form header' section.
The form header is used to display the form's title, the description and the current page the user is on.

## How to test
- Whilst logged in with form creation privileges
- Navigate to Webforms -  Admin > Webforms > Forms
- Create a multiple paged webform
- Click on the primary menu 'Settings' tab
- Click on the secondary menu 'General' tab
- Expand the fieldgroup 'Form header settings'
- Check the 'Display Form Header Block' checkbox
- Add a description to the 'User description' text area
- Click on the 'Save' button
- Verify that the form displays a Title, a horizontal line and a description and page title above the first input element.

Closes:[ Form Header](https://github.com/localgovdrupal/localgov_forms/issues/116)